### PR TITLE
feat: MCP 2026 protocol, dashboard redesign, JSONL adapters, comprehensive E2E suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,35 +7,32 @@ on:
     branches: [main]
 
 jobs:
-  check:
+  verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: Topos-Labs/infiniloom
+          ref: 46c5685580774461e2d77d6db2fc775218014aeb
           path: .infiniloom
-      - name: Symlink infiniloom for path dependency
+      - name: Link Infiniloom path dependency
         run: ln -s "$GITHUB_WORKSPACE/.infiniloom" "$GITHUB_WORKSPACE/../infiniloom"
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo check --workspace
-      - run: cargo test --workspace
-      - run: cargo clippy --workspace -- -D warnings
-
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # stable
         with:
-          repository: Topos-Labs/infiniloom
-          path: .infiniloom
-      - name: Symlink infiniloom for path dependency
-        run: ln -s "$GITHUB_WORKSPACE/.infiniloom" "$GITHUB_WORKSPACE/../infiniloom"
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - run: cargo fmt --all -- --check
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Default tests
+        run: cargo test --workspace --all-targets
+      - name: Code-analysis tests
+        run: cargo test --workspace --all-targets --features code-analysis
+      - name: Default lint
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Code-analysis lint
+        run: cargo clippy --workspace --all-targets --features code-analysis -- -D warnings
+      - name: Dashboard JavaScript syntax
+        run: node --check cli/src/web_dashboard.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,49 +4,53 @@ Guidelines for AI coding agents working on the Remembrant codebase.
 
 ## Project Overview
 
-Remembrant is a Rust-based CLI tool (`rem`) that ingests coding agent artifacts from Claude Code, Codex CLI, and Gemini CLI into a triple-database (DuckDB + LanceDB + DuckPGQ property graph) for shared persistent memory across AI coding agents. It includes Semantic XPath queries, optional 26-language code analysis via Infiniloom, and a Tauri v2 desktop app.
+Remembrant is a Rust-based CLI tool (`rem`) that ingests coding agent artifacts from Claude Code, Codex CLI, and Gemini CLI into DuckDB (structured rows plus a persistent property graph) and LanceDB for shared persistent memory across AI coding agents. It includes Semantic XPath, a local web dashboard/API, a stateless MCP server, optional 26-language code analysis via Infiniloom, and generic SQLite/JSONL agent adapters.
 
 ## Architecture
 
 ### Workspace Structure
 
-This is a Cargo workspace (edition 2024) with three crates:
+This is a Cargo workspace (edition 2024) with two crates:
 
 - **engine** (`remembrant-engine`): Core library — ingestion, storage, search, graph, Semantic XPath
-- **cli** (`remembrant`): Binary crate providing the `rem` CLI tool (22 commands) + web dashboard
+- **cli** (`remembrant`): Binary crate providing the `rem` CLI tool (26 commands), web dashboard/API, and MCP stdio server
 
 ### Key Modules
 
 **engine/src/**:
 - `store/` — Database implementations
-  - `duckdb.rs` — DuckStore: structured data + DuckPGQ graph (uses `Mutex<Connection>`)
+  - `duckdb.rs` — DuckStore: structured data, tags, analytics, and graph tables/algorithms (uses `Mutex<Connection>`)
   - `lance.rs` — LanceStore: vector embeddings + symbol embeddings (async)
   - `graph.rs` — GraphStoreBackend trait + in-memory GraphStore (fallback)
 - `ingest/` — Agent-specific parsers
   - `claude.rs` — ClaudeIngester (JSONL transcripts)
-  - `codex.rs` — CodexIngester (SQLite database)
+  - `codex.rs` — CodexIngester (rollout JSONL artifacts)
   - `gemini.rs` — GeminiIngester (JSON sessions)
+  - `jsonl_adapter.rs` — YAML-mapped generic JSONL adapter
+  - `native_adapters.rs` — config-aware registry for native and dynamic adapters
 - `semantic_tree.rs` — TreeBuilder, TreeNode, TreeNodeType, TreeSchema (hierarchical memory model)
 - `xpath_query.rs` — XPathQuery parser + evaluator (weighted-set algorithm from arXiv:2603.01160)
 - `semantic_scorer.rs` — SemanticScorer (embedding cache) + keyword_scorer (fallback)
 - `graph_builder.rs` — `GraphBuilder<B: GraphBackend>` generic over backend (in-memory or DuckDB)
 - `code_analysis.rs` — Infiniloom bridge (feature-gated: `code-analysis`)
-- `repo_embed.rs` — RepoEmbedder (AST chunking, BLAKE3 hashing, secret scanning)
+- `repo_embed.rs` — RepoEmbedder (AST/line chunking, content-addressable IDs, update-aware replacement)
 - `embed_pipeline.rs` — EmbedPipeline for batching embeddings
 - `embedding.rs` — EmbedProvider trait (LmStudioEmbedder, MockEmbedder)
 - `distill.rs` — Distiller for LLM-based insight extraction
-- `watcher.rs` — FileWatcher for monitoring agent directories
+- `watcher.rs` — Debounced FileWatcher for JSON/JSONL artifacts and agent MEMORY.md files
 - `pipeline.rs` — IngestPipeline for orchestrating ingestion
 - `config.rs` — AppConfig
 - `detect.rs` — Agent detection utilities
 
 **cli/src/**:
-- `main.rs` — 22 subcommands: init, watch, stop, search, find, recent, brief, patterns, decisions, related, graph, timeline, note, forget, export, embed, ingest, xpath, analyze, status, stats, gc
+- `main.rs` — 26 subcommands: init, watch, stop, search, find, recent, brief, context, consolidate, patterns, decisions, related, graph, timeline, note, forget, export, embed, ingest, status, stats, gc, analyze, web, mcp, xpath
+- `mcp_server.rs` — MCP `2026-07-28` stdio server with legacy initialize compatibility
+- `web_dashboard.html/css/js` — embedded same-origin dashboard assets
 
 ### Feature Flags
 
-- **default** — No optional features
-- **code-analysis** — Enables Infiniloom integration (AST parsing, secret scanning, BLAKE3 hashing). Adds `infiniloom-engine` and `blake3` dependencies.
+- **default** — Enables the bundled generic SQLite adapter feature (`sqlite-adapters`)
+- **code-analysis** — Enables Infiniloom integration (AST parsing, secret scanning, BLAKE3 hashing). Adds `infiniloom-engine` and `blake3`.
 
 ## Development Guidelines
 
@@ -59,8 +63,11 @@ cargo build
 # Build with code-analysis feature
 cargo build --features code-analysis
 
-# Run all tests (167 tests)
-cargo test
+# Run default unit, integration, and CLI E2E tests
+cargo test --workspace --all-targets
+
+# Run feature-gated tests
+cargo test --workspace --all-targets --features code-analysis
 
 # Run specific crate tests
 cargo test -p remembrant-engine
@@ -72,8 +79,12 @@ cargo run --bin rem -- --help
 # Format code
 cargo fmt --all
 
-# Check for issues
-cargo clippy --workspace
+# Check for issues (both feature configurations)
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features code-analysis -- -D warnings
+
+# Check embedded dashboard JavaScript
+node --check cli/src/web_dashboard.js
 ```
 
 ### Code Style
@@ -104,13 +115,13 @@ pub trait GraphBackend {
 // In-memory (for tests and fallback)
 pub type InMemoryGraphBuilder = GraphBuilder<GraphStore>;
 
-// Persistent (DuckDB + DuckPGQ)
+// Persistent (DuckDB graph tables)
 pub type DuckGraphBuilder = GraphBuilder<DuckStore>;
 ```
 
-#### DuckStore (Synchronous + DuckPGQ)
+#### DuckStore (Synchronous + Graph Tables)
 
-DuckStore uses `Mutex<Connection>` for thread-safe access. DuckPGQ adds graph queries:
+DuckStore uses `Mutex<Connection>` for thread-safe access. Graph algorithms operate directly on `graph_nodes`/`graph_edges` and do not require DuckPGQ:
 
 ```rust
 impl DuckStore {
@@ -121,12 +132,12 @@ impl DuckStore {
     pub fn insert_graph_node(&self, id: &str, kind: &str, name: &str, props: &str) -> Result<()>;
     pub fn insert_graph_edge(&self, from: &str, to: &str, kind: &str, props: &str) -> Result<()>;
 
-    // DuckPGQ queries
+    // Graph algorithms and optional extension loading
     pub fn load_duckpgq(&self) -> Result<()>;
     pub fn init_graph(&self) -> Result<()>;
     pub fn pgq_shortest_path(&self, from: &str, to: &str, max_depth: usize) -> Result<Vec<String>>;
-    pub fn pgq_pagerank(&self) -> Result<Vec<(String, f64)>>;
-    pub fn pgq_pattern_match(&self, pattern_sql: &str) -> Result<Vec<Vec<String>>>;
+    pub fn pgq_pagerank(&self, limit: usize) -> Result<Vec<(String, f64)>>;
+    pub fn pgq_pattern_match(&self, id: &str, edge_kind: &str, direction: &str) -> Result<Vec<Vec<String>>>;
 
     // Connection accessor (for TreeBuilder)
     pub fn connection(&self) -> &Mutex<Connection>;
@@ -135,15 +146,17 @@ impl DuckStore {
 
 #### LanceStore (Async)
 
-LanceStore is async throughout, with two table types:
+LanceStore is async throughout, with three explicit table schemas:
 
 ```rust
 impl LanceStore {
     pub async fn open(path: &Path) -> Result<Self>;
 
-    // General embeddings
-    pub async fn insert_embeddings(&self, chunks: Vec<EmbedChunk>) -> Result<()>;
-    pub async fn search(&self, query: &[f32], limit: usize) -> Result<Vec<SearchResult>>;
+    // Code and memory embeddings
+    pub async fn insert_code_embedding(&self, /* typed fields */) -> Result<()>;
+    pub async fn insert_memory_embedding(&self, /* typed fields */) -> Result<()>;
+    pub async fn search_code(&self, query: &[f32], limit: usize) -> Result<Vec<CodeSearchResult>>;
+    pub async fn search_memories(&self, query: &[f32], limit: usize) -> Result<Vec<MemorySearchResult>>;
 
     // Symbol embeddings (code analysis)
     pub async fn insert_symbol_embedding(&self, symbol: SymbolEmbedding) -> Result<()>;
@@ -187,6 +200,8 @@ for weighted_node in results {
 - Use `DuckStore::open_in_memory()` for tests (no cleanup needed)
 - Use `MockEmbedder` for embedding tests
 - Use `tempfile::tempdir()` for LanceDB paths in tests
+- CLI/E2E tests must set an isolated `HOME`; never use the developer’s real home
+- Add MCP protocol coverage in `cli/tests/e2e.rs` when changing `mcp_server.rs`
 - Feature-gated tests: `#[cfg(feature = "code-analysis")]`
 
 ### Database Schema
@@ -202,10 +217,12 @@ for weighted_node in results {
 - `code_analysis_runs` — Analysis run metadata
 - `graph_nodes` — Property graph nodes (id, kind, name, properties JSON)
 - `graph_edges` — Property graph edges (from_id, to_id, kind, properties JSON)
+- `memory_tags` — Persistent, case-insensitive tags for manual notes
 
 **LanceDB Tables**:
-- `embeddings` — General vector embeddings (id, project_id, content, vector)
-- `symbol_embeddings` — Code symbol embeddings (13 columns including PageRank)
+- `code_embeddings` — Code/session/tool vector embeddings with stable IDs
+- `memory_embeddings` — Memory vector embeddings with stable IDs
+- `symbol_embeddings` — Code symbol embeddings including PageRank and source spans
 
 ### Common Pitfalls
 
@@ -215,7 +232,9 @@ for weighted_node in results {
 4. **EmbedProvider generics**: Never try to use `&dyn EmbedProvider`
 5. **Tilde expansion**: Config paths use `~/` — expand with `dirs::home_dir()`
 6. **Feature gates**: Code analysis imports must be behind `#[cfg(feature = "code-analysis")]`
-7. **GraphBackend is all-string**: Node kind, properties are strings (serialized JSON for properties)
+7. **Dashboard is same-origin**: Do not reintroduce permissive CORS on local APIs
+8. **MCP is newline JSON-RPC**: stdout must contain responses only; logs belong on stderr
+9. **GraphBackend is all-string**: Node kind, properties are strings (serialized JSON for properties)
 
 ### Adding New Features
 
@@ -223,17 +242,18 @@ for weighted_node in results {
 2. Add tests (unit in same file, integration in `engine/tests/`)
 3. Add CLI subcommand in `cli/src/main.rs` if needed
 4. Update AGENTS.md and README.md
-5. Run `cargo test && cargo fmt --all && cargo clippy --workspace`
+5. Run both default and feature test/lint gates plus `node --check` when dashboard JS changed
 
 ### Dependencies
 
 Key dependencies (see workspace `Cargo.toml`):
-- `duckdb` 1.x — Embedded SQL database + DuckPGQ extension
+- `duckdb` 1.x — Embedded SQL database; optional DuckPGQ extension
+- `glob` — Dynamic JSONL file matching
 - `lancedb` 0.27 — Vector database
 - `arrow-array`, `arrow-schema` 57 — Arrow format (must match lancedb)
 - `tokio` — Async runtime
 - `clap` 4 — CLI argument parsing
-- `serde`, `serde_json`, `serde_yaml` — Serialization
+- `serde`, `serde_json`, `serde_norway` — Serialization (YAML uses the maintained `serde_norway` fork)
 - `tracing`, `tracing-subscriber` — Logging
 - `notify`, `notify-debouncer-mini` — File watching
 - `reqwest` 0.12 — HTTP client (LM Studio)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4744,11 +4744,11 @@ dependencies = [
  "clap",
  "dirs",
  "remembrant-engine",
+ "reqwest",
  "serde",
  "serde_json",
- "serde_yaml",
+ "tempfile",
  "tokio",
- "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -4766,6 +4766,7 @@ dependencies = [
  "dirs",
  "duckdb",
  "futures",
+ "glob",
  "infiniloom-engine",
  "lancedb",
  "notify",
@@ -4775,7 +4776,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_norway",
  "sha2",
  "tempfile",
  "thiserror",
@@ -5179,6 +5180,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
 ]
 
 [[package]]
@@ -6521,6 +6535,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "Shared persistent memory for coding agents"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_norway = "0.9"
 
 # Async
 tokio = { version = "1", features = ["full"] }
@@ -44,7 +44,6 @@ futures = "0.3"
 
 # Databases
 duckdb = { version = "1", features = ["bundled", "chrono"] }
-# kuzu = "0.11"  # TODO: re-enable when Rust SDK stabilizes
 lancedb = "0.27"
 
 # File watching
@@ -59,6 +58,7 @@ reqwest = { version = "0.12", features = ["json"] }
 
 # Regex
 regex = "1"
+glob = "0.3"
 
 # Directories
 dirs = "6"
@@ -68,4 +68,3 @@ rusqlite = { version = "0.34", features = ["bundled"] }
 
 # Web server
 axum = "0.8"
-tower-http = { version = "0.6", features = ["cors"] }

--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ No agent works in isolation anymore. Every session builds on everything that cam
 
 ## Key Features
 
-- **Multi-Agent Ingestion** — Native parsers for Claude Code (JSONL), Codex CLI (SQLite), and Gemini CLI (JSON)
-- **Triple-Database Architecture** — DuckDB (structured + graph via DuckPGQ), LanceDB (vector search), in-memory graph (fallback)
+- **Multi-Agent Ingestion** — Native parsers for Claude Code, Codex CLI, and Gemini CLI, plus YAML-configured SQLite and JSONL adapters
+- **Triple-Database Architecture** — DuckDB (structured data and a persistent property graph), LanceDB (vector search), and an in-memory graph backend for tests/fallback
 - **Semantic XPath** — Tree-structured memory queries based on [arXiv:2603.01160](https://arxiv.org/abs/2603.01160), 176.7% better recall than flat RAG
-- **DuckPGQ Graph Queries** — SQL/PGQ property graph: PageRank, shortest path, pattern matching — all inside DuckDB
+- **Graph Analytics** — Directed shortest path, PageRank, and edge-kind traversal directly over DuckDB graph tables; optional DuckPGQ extension loading is supported when installed
 - **Code Analysis** — AST parsing for 26 languages via Infiniloom integration (feature-gated)
-- **Repository Embedding** — Embed entire codebases with BLAKE3 content-addressable chunks
+- **Repository Embedding** — Embed entire codebases with content-addressable chunks and idempotent `--update` replacement
 - **Security Scanning** — Secret detection and redaction before embedding (via Infiniloom)
 - **LLM Distillation** — Extract insights, patterns, and decisions from raw sessions
-- **File Watching** — Real-time monitoring of agent artifact directories
-- **Web Dashboard** — Built-in web UI for visual exploration
+- **File Watching** — Debounced filesystem events for JSON/JSONL artifacts and agent MEMORY.md files, with polling only for dynamic SQLite adapters
+- **Web Dashboard and API** — Built-in same-origin web UI, analytics, and REST endpoints
+- **MCP Server** — Stateless Model Context Protocol `2026-07-28` over stdio, with legacy initialize compatibility
 - **Local-First** — All data stays local; uses LM Studio for embeddings
 
 ## Quick Start
@@ -59,7 +60,7 @@ rem analyze /path/to/project
 
 ```
                     +-----------+
-                    |  rem CLI  |  22 commands
+                    |  rem CLI  |  26 commands
                     +-----+-----+
                           |
                     +-----+-----+
@@ -70,13 +71,13 @@ rem analyze /path/to/project
           |               |               |
     +-----+-----+  +-----+-----+  +------+------+
     |  DuckDB   |  |  LanceDB  |  | Graph Store |
-    |  + DuckPGQ|  |  (Vector)  |  | (In-Memory) |
+                    |  + Graph  |  |  (Vector)  |  | (In-Memory) |
     +-----------+  +-----------+  +-------------+
 ```
 
 ### DuckDB (Structured Data + Property Graph)
 
-Stores all structured data and provides SQL/PGQ graph queries:
+Stores all structured data and provides persistent property-graph tables and graph algorithms:
 
 | Table | Purpose |
 |-------|---------|
@@ -87,37 +88,21 @@ Stores all structured data and provides SQL/PGQ graph queries:
 | `file_stats` | File statistics (LOC, complexity, change frequency) |
 | `code_symbols` | AST-parsed symbols (functions, classes, structs) |
 | `code_dependencies` | Import/call dependencies between files |
-| `graph_nodes` | Property graph nodes (via DuckPGQ) |
-| `graph_edges` | Property graph edges (via DuckPGQ) |
+| `graph_nodes` | Property graph nodes (kind, name, JSON properties) |
+| `graph_edges` | Property graph edges (kind, JSON properties) |
+| `memory_tags` | Case-insensitive tags for manual notes |
 
 ### LanceDB (Vector Embeddings)
 
 | Table | Purpose |
 |-------|---------|
-| `embeddings` | Session/memory embeddings for semantic search |
+| `code_embeddings` | Session/code-change/tool embeddings for semantic search |
+| `memory_embeddings` | Memory embeddings for semantic search |
 | `symbol_embeddings` | Code symbol embeddings with PageRank scores |
 
-### DuckPGQ (Property Graph)
+### Property graph
 
-DuckPGQ extends DuckDB with SQL/PGQ for graph operations — no separate graph database needed:
-
-```sql
--- Shortest path between two code entities
-SELECT * FROM GRAPH_TABLE(memory_graph
-  MATCH (a:Node)-[p:Edge]->{1,5}(b:Node)
-  WHERE a.id = 'fn-auth' AND b.id = 'fn-jwt'
-  COLUMNS (path_length(p))
-);
-
--- PageRank across the knowledge graph
-SELECT node_id, pagerank FROM pgq_pagerank('memory_graph', 'Node', 'Edge');
-
--- Pattern matching
-SELECT * FROM GRAPH_TABLE(memory_graph
-  MATCH (a:Node)-[:CALLS]->(b:Node)-[:IMPORTS]->(c:Node)
-  COLUMNS (a.name, b.name, c.name)
-);
-```
+Graph nodes and edges are ordinary DuckDB rows, so the graph survives restarts without a second database. `DuckStore` implements deterministic BFS shortest paths, iterative PageRank with dangling-node handling, and incoming/outgoing edge-kind matching directly against those tables. `init_graph()` and `load_duckpgq()` remain available for installations that have the optional DuckPGQ extension, but graph features do not require it.
 
 ## Semantic XPath
 
@@ -127,8 +112,8 @@ Based on the paper ["Semantic XPath: Tree-Structured Memory Access for LLM Agent
 Root
 ├── Project "remembrant"
 │   ├── Session "2026-03-20T14:30:00"
-│   │   ├── Decision "use DuckPGQ for graph"
-│   │   ├── Memory "DuckPGQ supports PageRank"
+│   │   ├── Decision "persist the graph in DuckDB"
+│   │   ├── Memory "PageRank handles dangling nodes"
 │   │   └── ToolCall "cargo test"
 │   └── Session "2026-03-21T09:00:00"
 │       └── CodeEntity "graph_builder.rs"
@@ -157,15 +142,16 @@ rem xpath '/Root/Project[@name="remembrant"]/Session/Decision'
 rem xpath '//Session[node~"refactor"]/Decision[node~"performance"]'
 ```
 
-The `~` operator triggers semantic similarity scoring (cosine similarity via LM Studio embeddings), while `@attr="value"` does exact attribute matching.
+The `~` operator applies semantic similarity scoring, while `@attr="value"` does exact matching. The CLI evaluator uses the deterministic keyword scorer by default so XPath works without a running embedding service.
 
 ## Supported Agents
 
 | Agent | Artifact Location | Format |
 |-------|------------------|--------|
 | **Claude Code** | `~/.claude/projects/*/` | JSONL transcripts + MEMORY.md |
-| **Codex CLI** | `~/.codex/sessions/` | SQLite database |
+| **Codex CLI** | `~/.codex/sessions/` | Rollout JSONL + `history.jsonl` |
 | **Gemini CLI** | `~/.gemini/tmp/*/chats/` | JSON session files |
+| **Configured agents** | Any local path | Generic SQLite or JSONL mappings |
 
 ## CLI Reference
 
@@ -175,7 +161,7 @@ The `~` operator triggers semantic similarity scoring (cosine similarity via LM 
 | `rem watch` | Start file watcher daemon |
 | `rem stop` | Stop the watcher daemon |
 | `rem ingest` | Ingest sessions from all agents |
-| `rem search <query>` | Semantic search (with `--project`, `--agent`, `--since` filters) |
+| `rem search <query>` | Hybrid semantic search (`--project`, `--agent`, `--type`, `--since`, `--json`) |
 | `rem find <text>` | Exact text search |
 | `rem recent` | Show recent sessions |
 | `rem brief` | Daily context briefing |
@@ -184,15 +170,19 @@ The `~` operator triggers semantic similarity scoring (cosine similarity via LM 
 | `rem related <path>` | Find related content for a file |
 | `rem graph <path>` | Show dependency graph |
 | `rem timeline <topic>` | Chronological topic view |
-| `rem note <text>` | Add a manual note |
+| `rem note <text>` | Add a manual note with persistent `--tag` values |
 | `rem forget --session <id>` | Remove a session |
 | `rem export` | Generate agent memory files |
-| `rem embed <path>` | Embed a repository for code search |
+| `rem embed <path>` | Embed a repository; `--update` replaces stale project vectors |
 | `rem xpath <query>` | Semantic XPath query |
 | `rem analyze <path>` | AST code analysis (requires `code-analysis` feature) |
 | `rem status` | Show daemon and database status |
 | `rem stats` | Show analytics and statistics |
 | `rem gc` | Garbage collect old/orphaned data |
+| `rem context` | Assemble a token-budgeted project context |
+| `rem consolidate` | Merge and decay related memories |
+| `rem web` | Serve the local dashboard and REST API |
+| `rem mcp` | Serve MCP tools over newline-delimited stdio JSON-RPC |
 
 ## Code Analysis (Feature-Gated)
 
@@ -216,31 +206,54 @@ rem xpath '//CodeEntity/Symbol[@kind="function"]'
 
 ## Configuration
 
-Config lives at `~/.config/remembrant/config.toml`:
+Config lives at `~/.remembrant/config.yaml` and is created on first use. Paths accept a leading `~`:
 
-```toml
-[storage]
-duckdb_path = "~/.remembrant/data.db"
-lancedb_path = "~/.remembrant/lance"
+```yaml
+storage:
+  duckdb_path: ~/.remembrant/remembrant.duckdb
+  lancedb_path: ~/.remembrant/lancedb
 
-[agents.claude_code]
-enabled = true
-watch_path = "~/.claude/projects"
+agents:
+  claude_code:
+    enabled: true
+    path: ~/.claude
+  codex:
+    enabled: true
+    path: ~/.codex
+  gemini:
+    enabled: true
+    path: ~/.gemini
+  dynamic:
+    - id: custom_jsonl_agent
+      display_name: Custom JSONL Agent
+      enabled: true
+      path: ~/.custom-agent
+      adapter_type: jsonl
+      jsonl:
+        file_pattern: "**/*.jsonl"
+        session_id_path: session.id
+        timestamp_path: timestamp
+        content_path: message.text
+        tool_name_path: tool.name
+        tool_call_type: kind=tool
 
-[agents.codex]
-enabled = true
-db_path = "~/.codex/sessions"
+embedding:
+  model: text-embedding-nomic-embed-text-v1.5@q8_0
+  endpoint: http://localhost:1234/v1
+  batch_size: 100
+  dimensions: 768
 
-[agents.gemini]
-enabled = true
-watch_path = "~/.gemini/tmp"
-
-[embedding]
-provider = "lmstudio"
-model = "nomic-embed-text"
-endpoint = "http://localhost:1234/v1"
-dimensions = 768
+watch:
+  debounce_ms: 5000
 ```
+
+Dynamic SQLite adapters use `adapter_type: sqlite` with table/column mappings under a `sqlite:` key. Unsupported adapter types fail explicitly rather than being ignored.
+
+## Web dashboard and MCP
+
+Run `rem web --port 7878` for the dashboard at `http://127.0.0.1:7878`. Static assets are embedded in the binary, and the API is same-origin; no permissive CORS layer is enabled.
+
+Run `rem mcp` for an MCP stdio server. It implements the stateless `2026-07-28` protocol, including `server/discover`, deterministic cacheable `tools/list` metadata, per-request `_meta` protocol validation, and `tools/call`. Legacy `initialize` clients remain supported. Nine memory tools are exposed: search, recall, add, context, XPath, decision recording, update, delete, and fact revision.
 
 ## Project Structure
 
@@ -249,14 +262,16 @@ remembrant/
 ├── engine/                    # Core library (remembrant-engine)
 │   ├── src/
 │   │   ├── store/
-│   │   │   ├── duckdb.rs      # DuckStore + DuckPGQ graph queries
+│   │   │   ├── duckdb.rs      # DuckStore + persistent graph algorithms
 │   │   │   ├── lance.rs       # LanceStore (vector + symbol embeddings)
 │   │   │   ├── graph.rs       # In-memory GraphStore + GraphStoreBackend trait
 │   │   │   └── mod.rs
 │   │   ├── ingest/
 │   │   │   ├── claude.rs      # Claude Code parser (JSONL)
-│   │   │   ├── codex.rs       # Codex CLI parser (SQLite)
-│   │   │   └── gemini.rs      # Gemini CLI parser (JSON)
+│   │   │   ├── codex.rs       # Codex CLI parser (JSONL)
+│   │   │   ├── gemini.rs      # Gemini CLI parser (JSON)
+│   │   │   ├── jsonl_adapter.rs # Generic YAML-mapped JSONL adapter
+│   │   │   └── native_adapters.rs # Config-aware adapter registry
 │   │   ├── semantic_tree.rs   # Tree-structured memory model (TreeBuilder, TreeNode)
 │   │   ├── xpath_query.rs     # Semantic XPath parser + evaluator
 │   │   ├── semantic_scorer.rs # Embedding-based semantic similarity scoring
@@ -272,7 +287,10 @@ remembrant/
 │   │   └── config.rs          # AppConfig
 │   └── tests/                 # Integration tests
 ├── cli/                       # CLI binary (rem)
-│   └── src/main.rs            # 22 subcommands
+│   ├── src/main.rs            # 26 subcommands, REST API, MCP entry point
+│   ├── src/mcp_server.rs      # MCP 2026-07-28 stdio server
+│   ├── src/web_dashboard.*    # Embedded HTML/CSS/JS dashboard
+│   └── tests/e2e.rs           # CLI, watcher, dashboard, and MCP E2E
 ├── .github/workflows/         # CI/CD
 ├── AGENTS.md                  # Guidelines for AI coding agents
 └── Cargo.toml                 # Workspace config (edition 2024)
@@ -284,8 +302,11 @@ remembrant/
 # Build the workspace
 cargo build
 
-# Run all tests (167 tests)
-cargo test
+# Run all default tests, including CLI E2E
+cargo test --workspace --all-targets
+
+# Verify the optional Infiniloom integration
+cargo test --workspace --all-targets --features code-analysis
 
 # Build with code-analysis feature
 cargo build --features code-analysis
@@ -296,23 +317,27 @@ cargo test -p remembrant
 
 # Format and lint
 cargo fmt --all
-cargo clippy --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --features code-analysis -- -D warnings
+
+# Dashboard JavaScript syntax gate
+node --check cli/src/web_dashboard.js
 ```
 
 ### Key Design Decisions
 
 - **Edition 2024 Rust** — latest language features
 - **Generic GraphBuilder** — `GraphBuilder<B: GraphBackend>` works with both in-memory and DuckDB backends
-- **DuckPGQ over separate graph DB** — zero data sync, same tables, built-in PageRank
+- **One DuckDB graph store** — no graph-database sync; algorithms work without optional extensions
 - **Feature-gated Infiniloom** — optional `code-analysis` feature avoids heavy tree-sitter deps when not needed
-- **Content-addressable chunks** — BLAKE3 hashing for deduplication
+- **Content-addressable chunks** — BLAKE3 with code analysis, stable SHA-256 fallback IDs otherwise
 - **Secrets never embedded** — security scanning runs before chunking/embedding
 
 ## How It Works
 
 1. **Detect** — Scan for installed agents (Claude Code, Codex, Gemini)
 2. **Ingest** — Agent-specific parsers extract sessions, tool calls, decisions, memories
-3. **Store** — Structured data goes to DuckDB, graph relationships built via DuckPGQ
+3. **Store** — Structured data goes to DuckDB; graph relationships persist in `graph_nodes` and `graph_edges`
 4. **Embed** — LM Studio generates embeddings, stored in LanceDB
 5. **Index** — Build hierarchical memory tree (Project > Session > Decision/Memory/ToolCall/CodeEntity > Symbol)
 6. **Query** — CLI provides semantic search, XPath queries, graph traversal, and analytics

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/main.rs"
 remembrant-engine = { path = "../engine" }
 serde.workspace = true
 serde_json.workspace = true
-serde_yaml.workspace = true
 tokio.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
@@ -22,9 +21,12 @@ chrono.workspace = true
 clap.workspace = true
 dirs.workspace = true
 axum.workspace = true
-tower-http.workspace = true
 uuid.workspace = true
 
 [features]
 default = []
 code-analysis = ["remembrant-engine/code-analysis"]
+
+[dev-dependencies]
+reqwest.workspace = true
+tempfile = "3"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -7,21 +8,19 @@ use axum::{
     Json as AxumJson, Router,
     extract::{Path as AxumPath, Query, State},
     http::StatusCode,
-    response::Html,
-    routing::{delete, get, post, put},
+    routing::{delete, get, post},
 };
-use chrono::NaiveDateTime;
+use chrono::{Datelike, NaiveDateTime};
 use clap::{Parser, Subcommand};
 mod mcp_server;
 
+use remembrant_engine::AppConfig;
 use remembrant_engine::distill::Distiller;
 use remembrant_engine::embed_pipeline::EmbedPipeline;
 use remembrant_engine::embedding::{EmbedProvider, LmStudioEmbedder};
 use remembrant_engine::graph_builder::{self, GraphBackend, GraphBuilder};
 use remembrant_engine::repo_embed::RepoEmbedder;
 use remembrant_engine::store::{DuckStore, LanceStore};
-use remembrant_engine::{AppConfig, ClaudeIngester, CodexIngester, GeminiIngester, detect_agents};
-use tower_http::cors::CorsLayer;
 
 #[derive(Parser)]
 #[command(
@@ -63,7 +62,7 @@ enum Commands {
         since: Option<String>,
 
         /// Filter by content type
-        #[arg(long, name = "type")]
+        #[arg(long = "type", alias = "content-type")]
         content_type: Option<String>,
 
         /// Use exact matching instead of semantic
@@ -339,6 +338,162 @@ fn pid_file_path() -> Result<PathBuf> {
     Ok(dir.join("daemon.pid"))
 }
 
+/// Return whether a Unix process is currently alive.
+#[cfg(unix)]
+fn process_is_running(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+/// Process probing is not currently supported on non-Unix targets.
+#[cfg(not(unix))]
+fn process_is_running(_pid: u32) -> bool {
+    false
+}
+
+/// Reject an active watcher PID file and remove stale markers.
+fn ensure_no_active_pid_file(pid_path: &std::path::Path) -> Result<()> {
+    if !pid_path.exists() {
+        return Ok(());
+    }
+
+    let existing = std::fs::read_to_string(pid_path)
+        .with_context(|| format!("failed to read {}", pid_path.display()))?;
+    let existing = existing
+        .trim()
+        .parse::<u32>()
+        .with_context(|| format!("invalid PID in {}: {existing}", pid_path.display()))?;
+    if process_is_running(existing) {
+        anyhow::bail!("watcher PID {existing} is already running; run `rem stop` first");
+    }
+
+    std::fs::remove_file(pid_path)
+        .with_context(|| format!("failed to remove stale {}", pid_path.display()))
+}
+
+/// Ingest only sessions whose normalized values changed.
+///
+/// Replacing a changed session atomically removes stale transcript-derived
+/// rows while preserving manual notes and decisions without a session source.
+fn ingest_watch_snapshot(
+    store: &DuckStore,
+    registry: &remembrant_engine::ingest::AdapterRegistry,
+    adapter_ids: Option<&HashSet<String>>,
+) -> Result<usize> {
+    let mut known: HashMap<String, _> = store
+        .get_recent_sessions(100_000)?
+        .into_iter()
+        .map(|session| (session.id.clone(), session))
+        .collect();
+    let mut ingested = 0;
+
+    for adapter in registry.detected() {
+        let meta = adapter.meta();
+        if adapter_ids.is_some_and(|ids| !ids.contains(&meta.id)) {
+            continue;
+        }
+
+        match adapter.ingest() {
+            Ok(result) => {
+                for error in result.errors {
+                    eprintln!("[watch] {} parse error: {error}", meta.display_name);
+                }
+
+                let mut changed_ids = HashSet::new();
+                for session in &result.sessions {
+                    let changed = known.get(&session.id).is_none_or(|previous| {
+                        previous.started_at != session.started_at
+                            || previous.ended_at != session.ended_at
+                            || previous.summary != session.summary
+                            || previous.message_count != session.message_count
+                            || previous.tool_call_count != session.tool_call_count
+                            || previous.total_tokens != session.total_tokens
+                            || previous.files_changed != session.files_changed
+                    });
+                    if !changed {
+                        continue;
+                    }
+
+                    store
+                        .insert_or_replace_session(session)
+                        .with_context(|| format!("failed to persist session {}", session.id))?;
+                    known.insert(session.id.clone(), session.clone());
+                    changed_ids.insert(session.id.clone());
+                }
+
+                if changed_ids.is_empty() {
+                    continue;
+                }
+
+                for tool_call in &result.tool_calls {
+                    if tool_call
+                        .session_id
+                        .as_ref()
+                        .is_some_and(|session_id| changed_ids.contains(session_id))
+                        && let Err(error) = store.insert_tool_call(tool_call)
+                    {
+                        eprintln!(
+                            "[watch] {} tool call persistence error: {error}",
+                            meta.display_name
+                        );
+                    }
+                }
+                for memory in &result.memories {
+                    if memory
+                        .source_session_id
+                        .as_ref()
+                        .is_some_and(|session_id| changed_ids.contains(session_id))
+                        && let Err(error) = store.insert_memory(memory)
+                    {
+                        eprintln!(
+                            "[watch] {} memory persistence error: {error}",
+                            meta.display_name
+                        );
+                    }
+                }
+
+                println!(
+                    "[watch] {}: ingested {} changed session(s)",
+                    meta.display_name,
+                    changed_ids.len()
+                );
+                ingested += changed_ids.len();
+            }
+            Err(error) => {
+                eprintln!("[watch] {} ingestion error: {error}", meta.display_name);
+            }
+        }
+    }
+
+    Ok(ingested)
+}
+
+/// Wait for the daemon's graceful shutdown signals.
+async fn wait_for_shutdown_signal() -> Result<()> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut interrupt = signal(SignalKind::interrupt())?;
+        let mut terminate = signal(SignalKind::terminate())?;
+        tokio::select! {
+            result = interrupt.recv() => result.context("interrupt channel closed")?,
+            result = terminate.recv() => result.context("terminate channel closed")?,
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await?;
+    }
+
+    Ok(())
+}
+
 /// Format a file size in human-readable form.
 fn human_size(bytes: u64) -> String {
     if bytes < 1024 {
@@ -355,24 +510,114 @@ fn parse_since(s: &str) -> Option<NaiveDateTime> {
     let now = chrono::Utc::now().naive_utc();
     if let Some(days) = s.strip_suffix('d') {
         let n: i64 = days.parse().ok()?;
-        return Some(now - chrono::Duration::days(n));
+        return now.checked_sub_signed(chrono::Duration::try_days(n)?);
     }
     if let Some(weeks) = s.strip_suffix('w') {
         let n: i64 = weeks.parse().ok()?;
-        return Some(now - chrono::Duration::weeks(n));
+        return now.checked_sub_signed(chrono::Duration::try_weeks(n)?);
     }
     if let Some(hours) = s.strip_suffix('h') {
         let n: i64 = hours.parse().ok()?;
-        return Some(now - chrono::Duration::hours(n));
+        return now.checked_sub_signed(chrono::Duration::try_hours(n)?);
     }
-    // Try ISO datetime first, then just date
-    chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
+    // RFC 3339 values are normalized to UTC; naive ISO values use the UTC
+    // convention used by Remembrant's DuckDB timestamps.
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|timestamp| timestamp.naive_utc())
+        .or_else(|| {
+            chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
+                .ok()
+                .or_else(|| {
+                    chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
+                        .ok()
+                        .map(|date| date.and_hms_opt(0, 0, 0).unwrap())
+                })
+        })
+}
+
+fn parse_since_required(since: Option<&str>) -> Result<Option<NaiveDateTime>> {
+    since
+        .map(|value| parse_since(value).with_context(|| format!("invalid --since value: {value}")))
+        .transpose()
+}
+
+fn parse_metadata_timestamp(value: &str) -> Option<NaiveDateTime> {
+    NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f")
         .ok()
         .or_else(|| {
-            chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
+            chrono::DateTime::parse_from_rfc3339(value)
                 .ok()
-                .map(|d| d.and_hms_opt(0, 0, 0).unwrap())
+                .map(|timestamp| timestamp.naive_utc())
         })
+}
+
+fn filter_search_results(
+    results: Vec<remembrant_engine::HybridResult>,
+    project: Option<&str>,
+    agent: Option<&str>,
+    content_type: Option<&str>,
+    since: Option<NaiveDateTime>,
+) -> Vec<remembrant_engine::HybridResult> {
+    results
+        .into_iter()
+        .filter(|result| {
+            if let Some(project_filter) = project {
+                let result_project = result
+                    .metadata
+                    .get("project")
+                    .map(|value| value.as_str())
+                    .unwrap_or_default();
+                if !result_project
+                    .to_lowercase()
+                    .contains(&project_filter.to_lowercase())
+                {
+                    return false;
+                }
+            }
+
+            if let Some(agent_filter) = agent {
+                let result_agent = result
+                    .metadata
+                    .get("agent")
+                    .map(|value| value.as_str())
+                    .unwrap_or_default();
+                if !result_agent.eq_ignore_ascii_case(agent_filter) {
+                    return false;
+                }
+            }
+
+            if let Some(type_filter) = content_type {
+                let result_type = result.result_type.to_string().to_lowercase();
+                let metadata_type = result
+                    .metadata
+                    .get("type")
+                    .map(|value| value.as_str())
+                    .unwrap_or_default()
+                    .to_lowercase();
+                if !result_type.contains(&type_filter.to_lowercase())
+                    && !metadata_type.contains(&type_filter.to_lowercase())
+                {
+                    return false;
+                }
+            }
+
+            if let Some(since) = since {
+                let timestamp = result
+                    .metadata
+                    .get("started_at")
+                    .or_else(|| result.metadata.get("created_at"))
+                    .or_else(|| result.metadata.get("valid_at"))
+                    .map(|value| value.as_str())
+                    .and_then(parse_metadata_timestamp);
+                if timestamp.is_none_or(|timestamp| timestamp < since) {
+                    return false;
+                }
+            }
+
+            true
+        })
+        .collect()
 }
 
 /// Open LanceDB at the configured (tilde-expanded) path.
@@ -393,6 +638,11 @@ fn truncate(s: &str, max_chars: usize) -> String {
     }
 }
 
+/// Return the start of the UTC calendar day containing `now`.
+fn utc_day_start(now: NaiveDateTime) -> NaiveDateTime {
+    now.date().and_hms_opt(0, 0, 0).unwrap_or(now)
+}
+
 // ---------------------------------------------------------------------------
 // Command implementations
 // ---------------------------------------------------------------------------
@@ -403,41 +653,24 @@ fn cmd_init() -> Result<()> {
     // 1. Load or create config
     let config = AppConfig::load()?;
     let config_dir = AppConfig::config_dir()?;
-    std::fs::create_dir_all(&config_dir)?;
+    std::fs::create_dir_all(&config_dir)
+        .with_context(|| format!("failed to create {}", config_dir.display()))?;
     println!("[config] Configuration at {}", config_dir.display());
 
     // 2. Detect agents
     println!("\n--- Agent Detection ---");
-    let detection = detect_agents();
+    let registry = remembrant_engine::ingest::build_registry_from_config(&config)?;
+    let detected: Vec<_> = registry
+        .adapters()
+        .iter()
+        .filter(|adapter| adapter.detect())
+        .map(|adapter| adapter.meta().clone())
+        .collect();
 
-    let mut agents_found = 0u32;
-    if let Some(ref info) = detection.claude_code {
-        println!(
-            "  [+] {} -- {} ({} sessions)",
-            info.name,
-            info.base_path.display(),
-            info.session_count
-        );
-        agents_found += 1;
+    for meta in &detected {
+        println!("  [+] {} -- {}", meta.display_name, meta.default_path);
     }
-    if let Some(ref info) = detection.codex {
-        println!(
-            "  [+] {} -- {} ({} sessions)",
-            info.name,
-            info.base_path.display(),
-            info.session_count
-        );
-        agents_found += 1;
-    }
-    if let Some(ref info) = detection.gemini {
-        println!(
-            "  [+] {} -- {} ({} sessions)",
-            info.name,
-            info.base_path.display(),
-            info.session_count
-        );
-        agents_found += 1;
-    }
+    let agents_found = detected.len();
     if agents_found == 0 {
         println!("  (no agents detected)");
     }
@@ -453,115 +686,69 @@ fn cmd_init() -> Result<()> {
     let mut total_sessions = 0usize;
     let mut total_memories = 0usize;
     let mut total_tool_calls = 0usize;
+    let mut parse_errors = 0usize;
 
-    // Claude Code
-    if detection.claude_code.is_some() {
-        match ClaudeIngester::new() {
-            Ok(ingester) => match ingester.ingest_all() {
-                Ok(result) => {
-                    let s_count = result.sessions.len();
-                    let m_count = result.memories.len();
-                    let t_count = result.tool_calls.len();
+    for adapter in registry.detected() {
+        let meta = adapter.meta();
+        let result = adapter
+            .ingest()
+            .with_context(|| format!("failed to ingest {}", meta.display_name))?;
 
-                    for session in &result.sessions {
-                        if let Err(e) = store.insert_session(session) {
-                            eprintln!("  [!] Failed to insert Claude session {}: {e}", session.id);
-                        }
-                    }
-                    for memory in &result.memories {
-                        if let Err(e) = store.insert_memory(memory) {
-                            eprintln!("  [!] Failed to insert Claude memory: {e}");
-                        }
-                    }
-
-                    total_sessions += s_count;
-                    total_memories += m_count;
-                    total_tool_calls += t_count;
-                    println!(
-                        "  Claude Code: {s_count} sessions, {t_count} tool calls, {m_count} memories"
-                    );
-                }
-                Err(e) => eprintln!("  [!] Claude Code ingestion error: {e}"),
-            },
-            Err(e) => eprintln!("  [!] Claude Code ingester init error: {e}"),
+        for session in &result.sessions {
+            store
+                .insert_or_replace_session(session)
+                .with_context(|| format!("failed to persist {} session {}", meta.id, session.id))?;
         }
-    }
-
-    // Codex
-    if detection.codex.is_some()
-        && let Some(ingester) = CodexIngester::new()
-    {
-        match ingester.ingest_all() {
-            Ok(result) => {
-                let s_count = result.sessions.len();
-                let m_count = result.memories.len();
-                let t_count = result.tool_calls.len();
-
-                for session in &result.sessions {
-                    if let Err(e) = store.insert_session(session) {
-                        eprintln!("  [!] Failed to insert Codex session {}: {e}", session.id);
-                    }
-                }
-                for memory in &result.memories {
-                    if let Err(e) = store.insert_memory(memory) {
-                        eprintln!("  [!] Failed to insert Codex memory: {e}");
-                    }
-                }
-
-                total_sessions += s_count;
-                total_memories += m_count;
-                total_tool_calls += t_count;
-                println!(
-                    "  Codex CLI:   {s_count} sessions, {t_count} tool calls, {m_count} memories"
-                );
-            }
-            Err(e) => eprintln!("  [!] Codex ingestion error: {e}"),
+        for memory in &result.memories {
+            store
+                .insert_memory(memory)
+                .with_context(|| format!("failed to persist {} memory", meta.id))?;
         }
-    }
-
-    // Gemini
-    if detection.gemini.is_some()
-        && let Some(ingester) = GeminiIngester::new()
-    {
-        let (result, sessions, _tool_calls, memories) = ingester.ingest_all();
-
-        for session in &sessions {
-            if let Err(e) = store.insert_session(session) {
-                eprintln!("  [!] Failed to insert Gemini session {}: {e}", session.id);
-            }
-        }
-        for memory in &memories {
-            if let Err(e) = store.insert_memory(memory) {
-                eprintln!("  [!] Failed to insert Gemini memory: {e}");
-            }
+        for tool_call in &result.tool_calls {
+            store.insert_tool_call(tool_call).with_context(|| {
+                format!("failed to persist {} tool call {}", meta.id, tool_call.id)
+            })?;
         }
 
-        total_sessions += result.sessions_found;
-        total_memories += result.memories_found;
-        total_tool_calls += result.tool_calls_found;
+        total_sessions += result.sessions.len();
+        total_memories += result.memories.len();
+        total_tool_calls += result.tool_calls.len();
         println!(
-            "  Gemini CLI:  {} sessions, {} tool calls, {} memories",
-            result.sessions_found, result.tool_calls_found, result.memories_found
+            "  {}: {} sessions, {} tool calls, {} memories",
+            meta.display_name,
+            result.sessions.len(),
+            result.tool_calls.len(),
+            result.memories.len()
         );
-        if !result.errors.is_empty() {
-            for err in &result.errors {
-                eprintln!("  [!] Gemini: {err}");
-            }
+        for error in &result.errors {
+            eprintln!("  [!] {} parse error: {error}", meta.id);
         }
+        parse_errors += result.errors.len();
+    }
+
+    if parse_errors > 0 {
+        anyhow::bail!(
+            "{parse_errors} agent artifact parse error(s) occurred during initialization"
+        );
     }
 
     // Populate projects and file_stats from ingested sessions
-    let all_sessions = store.get_recent_sessions(10_000).unwrap_or_default();
+    let session_count = store.count_sessions()?;
+    let all_sessions = store.get_recent_sessions(session_count.max(1))?;
     let mut projects_seen = std::collections::HashSet::new();
     let mut files_tracked = 0usize;
     for s in &all_sessions {
         if let Some(ref pid) = s.project_id {
             if projects_seen.insert(pid.clone()) {
                 let name = pid.rsplit('/').next().unwrap_or(pid);
-                let _ = store.upsert_project(pid, name, pid);
+                store
+                    .upsert_project(pid, name, pid)
+                    .with_context(|| format!("failed to persist project {pid}"))?;
             }
             for f in &s.files_changed {
-                let _ = store.upsert_file_stat(f, pid);
+                store
+                    .upsert_file_stat(f, pid)
+                    .with_context(|| format!("failed to persist file stat {f}"))?;
                 files_tracked += 1;
             }
         }
@@ -588,21 +775,18 @@ fn cmd_status() -> Result<()> {
     // 1. Daemon status
     let pid_path = pid_file_path()?;
     if pid_path.exists() {
-        let pid_str = std::fs::read_to_string(&pid_path).unwrap_or_default();
-        let pid_str = pid_str.trim();
-        // Check if process is running
-        let running = std::process::Command::new("kill")
-            .args(["-0", pid_str])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
+        let pid_text = std::fs::read_to_string(&pid_path)
+            .with_context(|| format!("failed to read {}", pid_path.display()))?;
+        let pid = pid_text
+            .trim()
+            .parse::<u32>()
+            .with_context(|| format!("invalid PID in {}: {pid_text}", pid_path.display()))?;
+        let running = process_is_running(pid);
 
         if running {
-            println!("[daemon] Running (PID {pid_str})");
+            println!("[daemon] Running (PID {pid})");
         } else {
-            println!("[daemon] Stale PID file (process {pid_str} not running)");
+            println!("[daemon] Stale PID file (process {pid} not running)");
         }
     } else {
         println!("[daemon] Not running");
@@ -610,33 +794,13 @@ fn cmd_status() -> Result<()> {
 
     // 2. Detected agents
     println!("\n--- Agents ---");
-    let detection = detect_agents();
-    let mut any_agent = false;
-    if let Some(ref info) = detection.claude_code {
-        println!(
-            "  Claude Code: {} ({} sessions)",
-            info.base_path.display(),
-            info.session_count
-        );
-        any_agent = true;
+    let registry = remembrant_engine::ingest::build_registry_from_config(&config)?;
+    let detected_agents = registry.detected();
+    for adapter in &detected_agents {
+        let meta = adapter.meta();
+        println!("  {}: {}", meta.display_name, meta.default_path);
     }
-    if let Some(ref info) = detection.codex {
-        println!(
-            "  Codex CLI:   {} ({} sessions)",
-            info.base_path.display(),
-            info.session_count
-        );
-        any_agent = true;
-    }
-    if let Some(ref info) = detection.gemini {
-        println!(
-            "  Gemini CLI:  {} ({} sessions)",
-            info.base_path.display(),
-            info.session_count
-        );
-        any_agent = true;
-    }
-    if !any_agent {
+    if detected_agents.is_empty() {
         println!("  (no agents detected)");
     }
 
@@ -646,26 +810,18 @@ fn cmd_status() -> Result<()> {
 
     let db_path = expand_tilde(&config.storage.duckdb_path);
     if db_path.exists() {
-        let size = std::fs::metadata(&db_path).map(|m| m.len()).unwrap_or(0);
+        let size = std::fs::metadata(&db_path)
+            .with_context(|| format!("failed to read metadata for {}", db_path.display()))?
+            .len();
         println!(
             "  DuckDB:      {} ({})",
             db_path.display(),
             human_size(size)
         );
 
-        // Row counts
-        match open_store(&config) {
-            Ok(store) => {
-                let sessions = store.get_recent_sessions(i32::MAX as usize)?;
-                println!("  Sessions:    {}", sessions.len());
-
-                let memories = store.search_memories("")?;
-                println!("  Memories:    {}", memories.len());
-            }
-            Err(e) => {
-                eprintln!("  [!] Could not open DuckDB: {e}");
-            }
-        }
+        let store = open_store(&config)?;
+        println!("  Sessions:    {}", store.count_sessions()?);
+        println!("  Memories:    {}", store.count_memories()?);
     } else {
         println!("  DuckDB:      {} (not created yet)", db_path.display());
         println!("  Run `rem init` first.");
@@ -676,131 +832,149 @@ fn cmd_status() -> Result<()> {
         println!("  LanceDB:     {}", lance_path.display());
     }
 
-    let graph_path = expand_tilde(&config.storage.graph_db_path);
-    if graph_path.exists() {
-        println!("  Graph DB:    {}", graph_path.display());
-    }
-
     Ok(())
 }
 
 async fn cmd_watch() -> Result<()> {
     let config = AppConfig::load()?;
-
-    // Write PID file
-    let pid = std::process::id();
     let pid_path = pid_file_path()?;
-    if let Some(parent) = pid_path.parent() {
-        std::fs::create_dir_all(parent)?;
+    ensure_no_active_pid_file(&pid_path)?;
+    let registry = Arc::new(remembrant_engine::ingest::build_registry_from_config(
+        &config,
+    )?);
+    let store = Arc::new(open_store(&config)?);
+    let watcher = remembrant_engine::FileWatcher::from_config(&config);
+
+    // Native JSONL/JSON/markdown adapters are event-driven. Configured SQLite
+    // adapters can be a single database file, so they retain a low-frequency
+    // polling fallback instead of forcing a filesystem watch onto a file that
+    // may be replaced atomically.
+    let native_adapter_ids: HashSet<String> = [
+        config.agents.claude_code.enabled.then_some("claude_code"),
+        config.agents.codex.enabled.then_some("codex"),
+        config.agents.gemini.enabled.then_some("gemini"),
+    ]
+    .into_iter()
+    .flatten()
+    .map(str::to_string)
+    .chain(
+        config
+            .agents
+            .dynamic
+            .iter()
+            .filter(|agent| agent.enabled && agent.adapter_type == "jsonl")
+            .map(|agent| agent.id.clone()),
+    )
+    .collect();
+    let dynamic_adapter_ids: HashSet<String> = config
+        .agents
+        .dynamic
+        .iter()
+        .filter(|agent| agent.enabled && agent.adapter_type == "sqlite")
+        .map(|agent| agent.id.clone())
+        .collect();
+    let active_native_paths = watcher
+        .watch_paths()
+        .iter()
+        .filter(|path| path.is_dir())
+        .count();
+    let poll_interval = std::time::Duration::from_millis(config.watch.debounce_ms.max(1_000));
+    if registry.detected().is_empty() {
+        anyhow::bail!(
+            "no enabled agent artifacts were detected; run `rem status` to inspect configured paths"
+        );
     }
-    std::fs::write(&pid_path, pid.to_string())?;
+
+    // Write the PID file after the configuration and database are known to be
+    // valid so a failed startup never leaves a stale daemon marker.
+    let pid = std::process::id();
+    if let Some(parent) = pid_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    std::fs::write(&pid_path, pid.to_string())
+        .with_context(|| format!("failed to write {}", pid_path.display()))?;
     println!("[watch] PID {pid} written to {}", pid_path.display());
-
-    let store = open_store(&config)?;
-    let debounce_secs = std::cmp::max(config.watch.debounce_ms / 1000, 5);
-
     println!(
-        "[watch] Watching for changes (polling every {debounce_secs}s). Press Ctrl+C to stop."
+        "[watch] Event watching {active_native_paths} native artifact director(y/ies); \
+        polling {} dynamic adapter(s) every {} ms. Press Ctrl+C to stop.",
+        dynamic_adapter_ids.len(),
+        poll_interval.as_millis()
     );
 
-    let pid_path_clone = pid_path.clone();
-    let shutdown = async {
-        tokio::signal::ctrl_c()
-            .await
-            .expect("failed to listen for Ctrl+C");
-    };
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+    let watcher_debounce = config.watch.debounce_ms;
+    std::thread::spawn(move || {
+        let file_watcher =
+            remembrant_engine::FileWatcher::new(watcher.watch_paths().to_vec(), watcher_debounce);
+        let sender = event_tx;
+        if let Err(error) = file_watcher.run(move |events| {
+            // An event is only a hint: ingestion performs a normalized
+            // diff, so duplicate or partial-write events are safe.
+            println!("[watch] received {} artifact change(s)", events.len());
+            let _ = sender.send(());
+        }) {
+            eprintln!("[watch] filesystem watcher error: {error}");
+        }
+        tracing::debug!("native watcher thread exited");
+    });
 
-    let poll_loop = async {
+    let event_registry = Arc::clone(&registry);
+    let event_store = Arc::clone(&store);
+    let native_ids = native_adapter_ids.clone();
+    tokio::spawn(async move {
+        while event_rx.recv().await.is_some() {
+            match ingest_watch_snapshot(&event_store, &event_registry, Some(&native_ids)) {
+                Ok(changed_sessions) if changed_sessions > 0 => match build_graph(&event_store) {
+                    Ok(graph) => println!(
+                        "[watch] rebuilt graph with {} nodes and {} edges",
+                        graph.node_count(),
+                        graph.edge_count()
+                    ),
+                    Err(error) => {
+                        eprintln!("[watch] graph rebuild error: {error:#}");
+                    }
+                },
+                Ok(_) => {}
+                Err(error) => {
+                    eprintln!("[watch] persistence error: {error:#}");
+                }
+            }
+        }
+    });
+
+    let poll_registry = Arc::clone(&registry);
+    let poll_store = Arc::clone(&store);
+    let poll_loop = async move {
+        if dynamic_adapter_ids.is_empty() {
+            std::future::pending::<()>().await;
+        }
         loop {
-            tokio::time::sleep(tokio::time::Duration::from_secs(debounce_secs)).await;
-
-            // Re-ingest Claude Code
-            if let Ok(ingester) = ClaudeIngester::new() {
-                match ingester.ingest_all() {
-                    Ok(result) => {
-                        if result.sessions_count > 0 {
-                            let mut inserted = 0usize;
-                            for session in &result.sessions {
-                                // Insert, ignoring duplicates
-                                if store.insert_session(session).is_ok() {
-                                    inserted += 1;
-                                }
-                            }
-                            for memory in &result.memories {
-                                let _ = store.insert_memory(memory);
-                            }
-                            if inserted > 0 {
-                                println!(
-                                    "[watch] Claude Code: ingested {inserted} sessions, {} memories",
-                                    result.memories_count
-                                );
-                            }
-                        }
+            tokio::time::sleep(poll_interval).await;
+            match ingest_watch_snapshot(&poll_store, &poll_registry, Some(&dynamic_adapter_ids)) {
+                Ok(changed_sessions) if changed_sessions > 0 => match build_graph(&poll_store) {
+                    Ok(graph) => println!(
+                        "[watch] rebuilt graph with {} nodes and {} edges",
+                        graph.node_count(),
+                        graph.edge_count()
+                    ),
+                    Err(error) => {
+                        eprintln!("[watch] graph rebuild error: {error:#}");
                     }
-                    Err(e) => {
-                        eprintln!("[watch] Claude Code ingestion error: {e}");
-                    }
-                }
-            }
-
-            // Re-ingest Codex
-            if let Some(ingester) = CodexIngester::new() {
-                match ingester.ingest_all() {
-                    Ok(result) => {
-                        let mut inserted = 0usize;
-                        for session in &result.sessions {
-                            if store.insert_session(session).is_ok() {
-                                inserted += 1;
-                            }
-                        }
-                        for memory in &result.memories {
-                            let _ = store.insert_memory(memory);
-                        }
-                        if inserted > 0 {
-                            println!(
-                                "[watch] Codex: ingested {inserted} sessions, {} memories",
-                                result.memories.len()
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("[watch] Codex ingestion error: {e}");
-                    }
-                }
-            }
-
-            // Re-ingest Gemini
-            if let Some(ingester) = GeminiIngester::new() {
-                let (_result, sessions, _tool_calls, memories) = ingester.ingest_all();
-                let mut inserted = 0usize;
-                for session in &sessions {
-                    if store.insert_session(session).is_ok() {
-                        inserted += 1;
-                    }
-                }
-                for memory in &memories {
-                    let _ = store.insert_memory(memory);
-                }
-                if inserted > 0 {
-                    println!(
-                        "[watch] Gemini: ingested {inserted} sessions, {} memories",
-                        memories.len()
-                    );
-                }
+                },
+                Ok(_) => {}
+                Err(error) => eprintln!("[watch] persistence error: {error:#}"),
             }
         }
     };
 
-    tokio::select! {
-        _ = shutdown => {
-            println!("\n[watch] Shutting down...");
-        }
-        _ = poll_loop => {}
-    }
+    wait_for_shutdown_signal().await?;
+    println!("\n[watch] Shutting down...");
+    drop(poll_loop);
 
-    // Cleanup PID file
-    if pid_path_clone.exists() {
-        let _ = std::fs::remove_file(&pid_path_clone);
+    if pid_path.exists() {
+        std::fs::remove_file(&pid_path)
+            .with_context(|| format!("failed to remove {}", pid_path.display()))?;
         println!("[watch] PID file removed");
     }
 
@@ -815,29 +989,45 @@ fn cmd_stop() -> Result<()> {
         return Ok(());
     }
 
-    let pid_str = std::fs::read_to_string(&pid_path).context("failed to read PID file")?;
-    let pid_str = pid_str.trim();
+    let pid_text = std::fs::read_to_string(&pid_path).context("failed to read PID file")?;
+    let pid = pid_text
+        .trim()
+        .parse::<u32>()
+        .with_context(|| format!("invalid PID in {}: {pid_text}", pid_path.display()))?;
 
-    println!("[stop] Sending SIGTERM to PID {pid_str}...");
+    println!("[stop] Sending SIGTERM to PID {pid}...");
 
     let status = std::process::Command::new("kill")
-        .args(["-TERM", pid_str])
+        .args(["-TERM", &pid.to_string()])
         .status()
         .context("failed to send SIGTERM")?;
 
     if status.success() {
         println!("[stop] Signal sent successfully");
     } else {
-        eprintln!("[stop] kill returned non-zero status (process may already be stopped)");
+        if process_is_running(pid) {
+            anyhow::bail!("failed to stop watcher PID {pid}");
+        }
+        println!("[stop] PID {pid} was already stopped; removing stale PID file");
     }
 
-    // Remove PID file
-    if let Err(e) = std::fs::remove_file(&pid_path) {
-        eprintln!("[stop] Warning: could not remove PID file: {e}");
-    } else {
-        println!("[stop] PID file removed");
+    // Give the daemon a moment to clean up its own marker, then finish the job
+    // if it exited before flushing.
+    for _ in 0..100 {
+        if !pid_path.exists() {
+            println!("[stop] PID file removed");
+            println!("[stop] Daemon stopped.");
+            return Ok(());
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
+    if process_is_running(pid) {
+        anyhow::bail!("watcher PID {pid} did not stop within five seconds");
+    }
+    std::fs::remove_file(&pid_path)
+        .with_context(|| format!("failed to remove stale PID file {}", pid_path.display()))?;
+    println!("[stop] PID file removed");
     println!("[stop] Daemon stopped.");
     Ok(())
 }
@@ -903,7 +1093,7 @@ fn cmd_recent(limit: usize, agent: Option<&str>, project: Option<&str>) -> Resul
             .collect::<String>();
 
         let id_display = if s.id.len() > 36 {
-            format!("{}...", &s.id[..33])
+            truncate(&s.id, 36)
         } else {
             s.id.clone()
         };
@@ -930,7 +1120,7 @@ async fn cmd_search(
     let config = AppConfig::load()?;
     let store = open_store(&config)?;
 
-    let since_dt = since.and_then(parse_since);
+    let since_dt = parse_since_required(since)?;
 
     // JSON output mode: uses HybridSearch text-only for fast agent-friendly results
     if json_output {
@@ -941,6 +1131,8 @@ async fn cmd_search(
         } else {
             search.search_text_only(query, 20)?
         };
+
+        let results = filter_search_results(results, project, agent, content_type, since_dt);
 
         let json_results: Vec<serde_json::Value> = results
             .iter()
@@ -983,13 +1175,7 @@ async fn cmd_search(
         match open_lance_store(&config).await {
             Ok(lance) => {
                 search
-                    .search(
-                        query,
-                        40,
-                        Some(&lance),
-                        None, // graph boost TODO: unify GraphStore/DuckStore backends
-                        Some(&embedder),
-                    )
+                    .search(query, 40, Some(&lance), Some(&store), Some(&embedder))
                     .await?
             }
             Err(e) => {
@@ -1000,45 +1186,10 @@ async fn cmd_search(
     };
 
     // Post-filter by project, agent, content_type, since
-    let results: Vec<_> = results
+    let results = filter_search_results(results, project, agent, content_type, since_dt)
         .into_iter()
-        .filter(|r| {
-            if let Some(proj) = project {
-                let rp = r.metadata.get("project").map(|s| s.as_str()).unwrap_or("");
-                if !rp.to_lowercase().contains(&proj.to_lowercase()) {
-                    return false;
-                }
-            }
-            if let Some(a) = agent {
-                let ra = r.metadata.get("agent").map(|s| s.as_str()).unwrap_or("");
-                if !ra.eq_ignore_ascii_case(a) {
-                    return false;
-                }
-            }
-            if let Some(ctype) = content_type {
-                let rt = r.metadata.get("type").map(|s| s.as_str()).unwrap_or("");
-                if !rt.to_lowercase().contains(&ctype.to_lowercase()) {
-                    return false;
-                }
-            }
-            if let Some(since_dt) = since_dt {
-                let ts_str = r
-                    .metadata
-                    .get("started_at")
-                    .or_else(|| r.metadata.get("created_at"))
-                    .or_else(|| r.metadata.get("valid_at"));
-                if let Some(ts) = ts_str
-                    && let Ok(ts) =
-                        chrono::NaiveDateTime::parse_from_str(ts, "%Y-%m-%d %H:%M:%S%.f")
-                    && ts < since_dt
-                {
-                    return false;
-                }
-            }
-            true
-        })
         .take(20)
-        .collect();
+        .collect::<Vec<_>>();
 
     if results.is_empty() {
         println!("No results found for: {query}");
@@ -1072,7 +1223,14 @@ fn cmd_find(query: &str) -> Result<()> {
     let config = AppConfig::load()?;
     let store = open_store(&config)?;
 
-    let memories = store.search_memories(query)?;
+    let mut memories = store.search_memories(query)?;
+    let mut memory_ids: std::collections::HashSet<String> =
+        memories.iter().map(|memory| memory.id.clone()).collect();
+    for memory in store.search_memories_by_tag(query, 100)? {
+        if memory_ids.insert(memory.id.clone()) {
+            memories.push(memory);
+        }
+    }
     let sessions = store.search_sessions_by_summary(query)?;
 
     let total = memories.len() + sessions.len();
@@ -1103,7 +1261,7 @@ fn cmd_find(query: &str) -> Result<()> {
                 .unwrap_or_else(|| "-".to_string());
             let summary = s.summary.as_deref().unwrap_or("-");
             let id_short = if s.id.len() > 12 {
-                format!("{}...", &s.id[..12])
+                truncate(&s.id, 12)
             } else {
                 s.id.clone()
             };
@@ -1130,7 +1288,7 @@ fn cmd_brief(project: Option<&str>, today: bool, json_output: bool) -> Result<()
 
     // Determine time window
     let since = if today {
-        now - chrono::Duration::hours(24)
+        utc_day_start(now)
     } else {
         now - chrono::Duration::days(3)
     };
@@ -1202,7 +1360,7 @@ fn cmd_brief(project: Option<&str>, today: bool, json_output: bool) -> Result<()
         return Ok(());
     }
 
-    let window_label = if today { "24h" } else { "3 days" };
+    let window_label = if today { "today" } else { "3 days" };
 
     println!("=== Daily Brief ({}) ===\n", today_date.format("%Y-%m-%d"));
 
@@ -1317,6 +1475,10 @@ fn cmd_context_topic(
 }
 
 fn cmd_consolidate(project: Option<&str>, threshold: f64, json: bool) -> Result<()> {
+    if !threshold.is_finite() || !(0.0..=1.0).contains(&threshold) {
+        anyhow::bail!("--threshold must be between 0.0 and 1.0");
+    }
+
     let config = AppConfig::load()?;
     let store = open_store(&config)?;
 
@@ -1458,20 +1620,17 @@ fn cmd_timeline(topic: &str, since: Option<&str>) -> Result<()> {
 
     // Apply optional since filter
     let (sessions, memories) = if let Some(since_str) = since {
-        if let Some(since_dt) = parse_since(since_str) {
-            let filtered_sessions: Vec<_> = sessions
-                .into_iter()
-                .filter(|s| s.started_at.is_some_and(|dt| dt >= since_dt))
-                .collect();
-            let filtered_memories: Vec<_> = memories
-                .into_iter()
-                .filter(|m| m.created_at.is_some_and(|dt| dt >= since_dt))
-                .collect();
-            (filtered_sessions, filtered_memories)
-        } else {
-            eprintln!("Warning: could not parse --since value: {since_str}");
-            (sessions, memories)
-        }
+        let since_dt = parse_since_required(Some(since_str))?
+            .context("a --since value must produce a timestamp")?;
+        let filtered_sessions: Vec<_> = sessions
+            .into_iter()
+            .filter(|s| s.started_at.is_some_and(|dt| dt >= since_dt))
+            .collect();
+        let filtered_memories: Vec<_> = memories
+            .into_iter()
+            .filter(|m| m.created_at.is_some_and(|dt| dt >= since_dt))
+            .collect();
+        (filtered_sessions, filtered_memories)
     } else {
         (sessions, memories)
     };
@@ -1612,7 +1771,7 @@ fn cmd_note(text: &str, project: Option<&str>, tags: Option<&[String]>) -> Resul
     let config = AppConfig::load()?;
     let store = open_store(&config)?;
 
-    let id = store.insert_note(text, project)?;
+    let id = store.insert_note_with_tags(text, project, tags.unwrap_or_default())?;
 
     let tag_str = tags.map(|t| t.join(", ")).unwrap_or_default();
 
@@ -1633,12 +1792,16 @@ fn cmd_forget(session_id: &str) -> Result<()> {
     if store.delete_session(session_id)? {
         println!("Session {session_id} deleted.");
     } else {
-        println!("Session {session_id} not found.");
+        anyhow::bail!("Session {session_id} not found");
     }
     Ok(())
 }
 
 fn cmd_export(project: Option<&str>, format: &str, output: Option<&str>) -> Result<()> {
+    if !matches!(format, "markdown" | "json") {
+        anyhow::bail!("unsupported export format '{format}'; use markdown or json");
+    }
+
     let config = AppConfig::load()?;
     let store = open_store(&config)?;
 
@@ -1647,7 +1810,8 @@ fn cmd_export(project: Option<&str>, format: &str, output: Option<&str>) -> Resu
     let sessions = if let Some(proj) = project {
         store.get_project_sessions(proj)?
     } else {
-        store.get_recent_sessions(100)?
+        let session_count = store.count_sessions()?;
+        store.get_recent_sessions(session_count.max(1))?
     };
 
     let content = match format {
@@ -1734,7 +1898,7 @@ fn cmd_export(project: Option<&str>, format: &str, output: Option<&str>) -> Resu
                         .started_at
                         .map(|dt| dt.format("%Y-%m-%d").to_string())
                         .unwrap_or_default();
-                    let id_short = if s.id.len() > 8 { &s.id[..8] } else { &s.id };
+                    let id_short = truncate(&s.id, 8);
                     md.push_str(&format!("- {id_short}: {summary} ({date}, {})\n", s.agent));
                 }
             }
@@ -1853,7 +2017,12 @@ fn cmd_gc() -> Result<()> {
     let store = open_store(&config)?;
 
     let retention_days = config.retention.raw_transcripts_days;
-    let cutoff = chrono::Utc::now().naive_utc() - chrono::Duration::days(retention_days as i64);
+    let retention_duration = chrono::Duration::try_days(retention_days as i64)
+        .context("retention duration is out of range")?;
+    let cutoff = chrono::Utc::now()
+        .naive_utc()
+        .checked_sub_signed(retention_duration)
+        .context("retention cutoff is out of range")?;
 
     // Get DB size before
     let db_path = expand_tilde(&config.storage.duckdb_path);
@@ -1864,6 +2033,7 @@ fn cmd_gc() -> Result<()> {
     };
 
     let deleted = store.gc_sessions_before(cutoff)?;
+    let orphaned_tool_calls = store.delete_orphaned_tool_calls()?;
 
     let size_after = if db_path.exists() {
         std::fs::metadata(&db_path).map(|m| m.len()).unwrap_or(0)
@@ -1875,6 +2045,7 @@ fn cmd_gc() -> Result<()> {
 
     println!("Garbage collection:");
     println!("  Deleted {deleted} sessions older than {retention_days} days");
+    println!("  Deleted {orphaned_tool_calls} orphaned tool calls");
     println!("  Freed ~{}", human_size(freed));
 
     Ok(())
@@ -1890,98 +2061,62 @@ async fn cmd_ingest(skip_embed: bool, skip_distill: bool) -> Result<()> {
 
     // ── Step 1: Detect & parse agent artifacts ──────────────────────
     println!("▸ Step 1/4: Parsing agent artifacts...");
-    let detection = detect_agents();
 
     let mut all_sessions = Vec::new();
     let mut all_memories = Vec::new();
     let mut all_tool_calls = Vec::new();
+    let mut parse_errors = 0usize;
 
-    // Claude Code
-    if detection.claude_code.is_some() {
-        match ClaudeIngester::new() {
-            Ok(ingester) => match ingester.ingest_all() {
-                Ok(result) => {
-                    println!(
-                        "  ✓ Claude Code: {} sessions, {} tool calls, {} memories",
-                        result.sessions.len(),
-                        result.tool_calls.len(),
-                        result.memories.len()
-                    );
-                    for s in &result.sessions {
-                        let _ = store.insert_or_replace_session(s);
-                    }
-                    for m in &result.memories {
-                        let _ = store.insert_memory(m);
-                    }
-                    for tc in &result.tool_calls {
-                        let _ = store.insert_tool_call(tc);
-                    }
-                    all_sessions.extend(result.sessions);
-                    all_memories.extend(result.memories);
-                    all_tool_calls.extend(result.tool_calls);
-                }
-                Err(e) => eprintln!("  ✗ Claude Code: {e}"),
-            },
-            Err(e) => eprintln!("  ✗ Claude Code init: {e}"),
-        }
-    }
-
-    // Codex
-    if detection.codex.is_some()
-        && let Some(ingester) = CodexIngester::new()
-    {
-        match ingester.ingest_all() {
+    let registry = remembrant_engine::ingest::build_registry_from_config(&config)?;
+    for adapter in registry.detected() {
+        let meta = adapter.meta();
+        match adapter.ingest() {
             Ok(result) => {
                 println!(
-                    "  ✓ Codex CLI:   {} sessions, {} tool calls, {} memories",
+                    "  ✓ {}: {} sessions, {} tool calls, {} memories",
+                    meta.display_name,
                     result.sessions.len(),
                     result.tool_calls.len(),
                     result.memories.len()
                 );
-                for s in &result.sessions {
-                    let _ = store.insert_or_replace_session(s);
+
+                for session in &result.sessions {
+                    store.insert_or_replace_session(session).with_context(|| {
+                        format!("failed to persist {} session {}", meta.id, session.id)
+                    })?;
                 }
-                for m in &result.memories {
-                    let _ = store.insert_memory(m);
+                for memory in &result.memories {
+                    store
+                        .insert_memory(memory)
+                        .with_context(|| format!("failed to persist {} memory", meta.id))?;
                 }
-                for tc in &result.tool_calls {
-                    let _ = store.insert_tool_call(tc);
+                for tool_call in &result.tool_calls {
+                    store.insert_tool_call(tool_call).with_context(|| {
+                        format!("failed to persist {} tool call {}", meta.id, tool_call.id)
+                    })?;
                 }
+
                 all_sessions.extend(result.sessions);
                 all_memories.extend(result.memories);
                 all_tool_calls.extend(result.tool_calls);
+                for error in &result.errors {
+                    eprintln!("  ! {} parse error: {error}", meta.id);
+                }
+                parse_errors += result.errors.len();
             }
-            Err(e) => eprintln!("  ✗ Codex CLI: {e}"),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to ingest {}", meta.display_name));
+            }
         }
     }
-
-    // Gemini
-    if detection.gemini.is_some()
-        && let Some(ingester) = GeminiIngester::new()
-    {
-        let (result, sessions, tool_calls, memories) = ingester.ingest_all();
-        println!(
-            "  ✓ Gemini CLI:  {} sessions, {} tool calls, {} memories",
-            result.sessions_found, result.tool_calls_found, result.memories_found
-        );
-        for s in &sessions {
-            let _ = store.insert_or_replace_session(s);
-        }
-        for m in &memories {
-            let _ = store.insert_memory(m);
-        }
-        for tc in &tool_calls {
-            let _ = store.insert_tool_call(tc);
-        }
-        all_sessions.extend(sessions);
-        all_memories.extend(memories);
-        all_tool_calls.extend(tool_calls);
-    }
-
     let total_s = all_sessions.len();
     let total_m = all_memories.len();
     let total_tc = all_tool_calls.len();
     println!("\n  Total: {total_s} sessions, {total_tc} tool calls, {total_m} memories → DuckDB ✓");
+    if parse_errors > 0 {
+        anyhow::bail!("{parse_errors} agent artifact parse error(s) occurred during ingestion");
+    }
 
     // ── Step 2: LLM Distillation ────────────────────────────────────
     if skip_distill {
@@ -2015,15 +2150,21 @@ async fn cmd_ingest(skip_embed: bool, skip_distill: bool) -> Result<()> {
             match distiller.distill_session(session, &text).await {
                 Ok(distilled) => {
                     for d in distiller.to_decisions(&distilled) {
-                        let _ = store.insert_decision(&d);
+                        store
+                            .insert_decision(&d)
+                            .context("failed to persist distilled decision")?;
                         decisions_count += 1;
                     }
                     for m in distiller.to_memories(&distilled) {
-                        let _ = store.insert_memory(&m);
+                        store
+                            .insert_memory(&m)
+                            .context("failed to persist distilled memory")?;
                         patterns_count += 1;
                     }
                     for f in distiller.to_facts(&distilled, Some(&session.agent)) {
-                        let _ = store.upsert_fact(&f);
+                        store
+                            .upsert_fact(&f)
+                            .context("failed to persist distilled fact")?;
                         facts_count += 1;
                     }
                     problems_count += distilled.problems.len();
@@ -2077,6 +2218,9 @@ async fn cmd_ingest(skip_embed: bool, skip_distill: bool) -> Result<()> {
             "  Embedded: {} chunks ({} stored, {} errors)",
             stats.chunks_embedded, stats.chunks_stored, stats.errors
         );
+        if stats.errors > 0 {
+            anyhow::bail!("embedding pipeline reported {} errors", stats.errors);
+        }
     }
 
     // ── Step 4: Graph ───────────────────────────────────────────────
@@ -2105,9 +2249,12 @@ fn print_summary(sessions: usize, memories: usize, tool_calls: usize) {
 
 /// Build an in-memory graph from all DuckDB data.
 fn build_graph(store: &DuckStore) -> Result<GraphBuilder<&DuckStore>> {
-    let sessions = store.get_recent_sessions(10_000)?;
-    let memories = store.get_memories(None, 10_000)?;
-    let decisions = store.get_decisions(None, 10_000)?;
+    let session_count = store.count_sessions()?;
+    let memory_count = store.count_memories()?;
+    let decision_count = store.count_decisions()?;
+    let sessions = store.get_recent_sessions(session_count.max(1))?;
+    let memories = store.get_memories(None, memory_count.max(1))?;
+    let decisions = store.get_decisions(None, decision_count.max(1))?;
     let tool_calls = Vec::new();
 
     let builder = GraphBuilder::with_backend(store);
@@ -2115,8 +2262,7 @@ fn build_graph(store: &DuckStore) -> Result<GraphBuilder<&DuckStore>> {
     Ok(builder)
 }
 
-#[allow(unused_variables)]
-fn cmd_analyze(path: &str, project: Option<&str>) -> Result<()> {
+fn cmd_analyze(_path: &str, _project: Option<&str>) -> Result<()> {
     #[cfg(not(feature = "code-analysis"))]
     {
         anyhow::bail!(
@@ -2131,9 +2277,9 @@ fn cmd_analyze(path: &str, project: Option<&str>) -> Result<()> {
 
         let config = AppConfig::load()?;
         let store = open_store(&config)?;
-        let repo_path = expand_tilde(path);
+        let repo_path = expand_tilde(_path);
 
-        let project_id = project.map(String::from).unwrap_or_else(|| {
+        let project_id = _project.map(String::from).unwrap_or_else(|| {
             repo_path
                 .file_name()
                 .and_then(|n| n.to_str())
@@ -2146,10 +2292,9 @@ fn cmd_analyze(path: &str, project: Option<&str>) -> Result<()> {
 
         let analyzer = CodeAnalyzer::new(&project_id, &repo_path);
 
-        // Use an in-memory graph store for code analysis population
-        let graph_store = remembrant_engine::store::graph::GraphStore::new();
-
-        let result = analyzer.analyze(&store, &graph_store)?;
+        // Persist code graph relationships in DuckDB alongside the symbol rows.
+        let graph = GraphBuilder::with_backend(&store);
+        let result = analyzer.analyze(&store, graph.backend())?;
 
         println!("\nAnalysis complete:");
         println!("  Files analyzed:    {}", result.files_analyzed);
@@ -2161,12 +2306,15 @@ fn cmd_analyze(path: &str, project: Option<&str>) -> Result<()> {
     }
 }
 
-async fn cmd_embed(path: &str, _update: bool) -> Result<()> {
+async fn cmd_embed(path: &str, update: bool) -> Result<()> {
     let config = AppConfig::load()?;
     let abs_path =
         std::fs::canonicalize(path).with_context(|| format!("failed to resolve path: {path}"))?;
 
     println!("Embedding repository: {}", abs_path.display());
+    if update {
+        println!("Mode: replace existing embeddings for this project");
+    }
 
     let embedder = RepoEmbedder::new(&abs_path);
 
@@ -2186,7 +2334,12 @@ async fn cmd_embed(path: &str, _update: bool) -> Result<()> {
     let lance_store = open_lance_store(&config).await?;
 
     let result = embedder
-        .embed_and_store(&embed_provider, &lance_store, config.embedding.batch_size)
+        .embed_and_store_with_update(
+            &embed_provider,
+            &lance_store,
+            config.embedding.batch_size,
+            update,
+        )
         .await;
 
     match result {
@@ -2199,6 +2352,7 @@ async fn cmd_embed(path: &str, _update: bool) -> Result<()> {
             );
             if result.errors > 0 {
                 println!("  Errors: {}", result.errors);
+                anyhow::bail!("{} repository chunk(s) failed to embed", result.errors);
             }
         }
         Err(e) => {
@@ -2213,6 +2367,7 @@ async fn cmd_embed(path: &str, _update: bool) -> Result<()> {
                      4. Run `rem embed` again\n\n\
                      Underlying error: {e:#}"
                 );
+                return Err(e).context("embed failed");
             } else {
                 return Err(e).context("embed failed");
             }
@@ -2317,35 +2472,111 @@ impl WebState {
     }
 }
 
-async fn web_index() -> Html<&'static str> {
-    Html(include_str!("web_dashboard.html"))
+/// Keep local API page sizes bounded without rejecting client typos such as
+/// zero or an accidentally enormous value.
+fn api_limit(requested: Option<usize>, default: usize, maximum: usize) -> usize {
+    requested.unwrap_or(default).clamp(1, maximum)
+}
+
+async fn web_index() -> impl axum::response::IntoResponse {
+    (
+        [
+            (axum::http::header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (axum::http::header::CACHE_CONTROL, "no-store"),
+        ],
+        include_str!("web_dashboard.html"),
+    )
+}
+
+async fn web_dashboard_css() -> impl axum::response::IntoResponse {
+    (
+        [
+            (axum::http::header::CONTENT_TYPE, "text/css; charset=utf-8"),
+            (axum::http::header::CACHE_CONTROL, "no-cache"),
+        ],
+        include_str!("web_dashboard.css"),
+    )
+}
+
+async fn web_dashboard_js() -> impl axum::response::IntoResponse {
+    (
+        [
+            (
+                axum::http::header::CONTENT_TYPE,
+                "application/javascript; charset=utf-8",
+            ),
+            (axum::http::header::CACHE_CONTROL, "no-cache"),
+        ],
+        include_str!("web_dashboard.js"),
+    )
 }
 
 async fn web_stats(
     State(state): State<Arc<WebState>>,
 ) -> Result<axum::Json<serde_json::Value>, StatusCode> {
     let store = state.store()?;
-    let sessions = store
-        .count_sessions()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let memories = store
-        .count_memories()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let decisions = store
-        .count_decisions()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let tool_calls = store
-        .count_tool_calls()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let projects = store
-        .get_project_ids()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let map_store_error = |_| StatusCode::INTERNAL_SERVER_ERROR;
+    let sessions = store.count_sessions().map_err(map_store_error)?;
+    let memories = store.count_memories().map_err(map_store_error)?;
+    let decisions = store.count_decisions().map_err(map_store_error)?;
+    let tool_calls = store.count_tool_calls().map_err(map_store_error)?;
+    let facts = store.count_facts().map_err(map_store_error)?;
+    let active_facts = store.count_active_facts().map_err(map_store_error)?;
+    let projects = store.get_project_ids().map_err(map_store_error)?;
+
+    let now = chrono::Utc::now().naive_utc();
+    let today_start = now.date().and_hms_opt(0, 0, 0).unwrap_or(now);
+    let week_start = (now - chrono::Duration::days(7))
+        .date()
+        .and_hms_opt(0, 0, 0)
+        .unwrap_or(now);
+
+    let today_sessions = store
+        .count_sessions_since(today_start)
+        .map_err(map_store_error)?;
+    let today_memories = store
+        .count_memories_since(today_start)
+        .map_err(map_store_error)?;
+    let today_decisions = store
+        .count_decisions_since(today_start)
+        .map_err(map_store_error)?;
+    let today_tool_calls = store
+        .count_tool_calls_since(today_start)
+        .map_err(map_store_error)?;
+
+    let week_sessions = store
+        .count_sessions_since(week_start)
+        .map_err(map_store_error)?;
+    let week_memories = store
+        .count_memories_since(week_start)
+        .map_err(map_store_error)?;
+    let week_decisions = store
+        .count_decisions_since(week_start)
+        .map_err(map_store_error)?;
+    let week_tool_calls = store
+        .count_tool_calls_since(week_start)
+        .map_err(map_store_error)?;
+
     Ok(axum::Json(serde_json::json!({
         "sessions": sessions,
         "memories": memories,
         "decisions": decisions,
         "tool_calls": tool_calls,
+        "facts": facts,
+        "active_facts": active_facts,
         "projects": projects.len(),
+        "today": {
+            "sessions": today_sessions,
+            "memories": today_memories,
+            "decisions": today_decisions,
+            "tool_calls": today_tool_calls,
+        },
+        "week": {
+            "sessions": week_sessions,
+            "memories": week_memories,
+            "decisions": week_decisions,
+            "tool_calls": week_tool_calls,
+        },
     })))
 }
 
@@ -2357,7 +2588,7 @@ async fn web_projects(
         .get_project_ids()
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(axum::Json(
-        serde_json::to_value(&projects).unwrap_or_default(),
+        serde_json::to_value(&projects).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
     ))
 }
 
@@ -2373,12 +2604,12 @@ async fn web_sessions(
     Query(q): Query<SessionsQuery>,
 ) -> Result<axum::Json<serde_json::Value>, StatusCode> {
     let store = state.store()?;
-    let limit = q.limit.unwrap_or(200);
+    let limit = api_limit(q.limit, 200, 1_000);
     let sessions = store
         .search_sessions(q.agent.as_deref(), q.project.as_deref(), None, limit)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(axum::Json(
-        serde_json::to_value(&sessions).unwrap_or_default(),
+        serde_json::to_value(&sessions).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
     ))
 }
 
@@ -2387,13 +2618,10 @@ async fn web_session_detail(
     AxumPath(id): AxumPath<String>,
 ) -> Result<axum::Json<serde_json::Value>, StatusCode> {
     let store = state.store()?;
-    let sessions = store
-        .search_sessions(None, None, None, 10_000)
+    let session = store
+        .get_session(&id)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let session = sessions
-        .into_iter()
-        .find(|s| s.id == id)
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let session = session.ok_or(StatusCode::NOT_FOUND)?;
     let tool_calls = store
         .get_tool_calls_for_session(&id)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -2406,6 +2634,7 @@ async fn web_session_detail(
 #[derive(serde::Deserialize)]
 struct MemoriesQuery {
     project: Option<String>,
+    tag: Option<String>,
     limit: Option<usize>,
 }
 
@@ -2414,12 +2643,36 @@ async fn web_memories(
     Query(q): Query<MemoriesQuery>,
 ) -> Result<axum::Json<serde_json::Value>, StatusCode> {
     let store = state.store()?;
-    let memories = store
-        .get_memories(q.project.as_deref(), q.limit.unwrap_or(200))
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    Ok(axum::Json(
-        serde_json::to_value(&memories).unwrap_or_default(),
-    ))
+    let limit = api_limit(q.limit, 200, 1_000);
+    let memories = if let Some(tag) = q.tag.as_deref() {
+        store
+            .search_memories_by_tag(tag, limit)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            .into_iter()
+            .filter(|memory| {
+                q.project
+                    .as_deref()
+                    .is_none_or(|project| memory.project_id.as_deref() == Some(project))
+            })
+            .collect::<Vec<_>>()
+    } else {
+        store
+            .get_memories(q.project.as_deref(), limit)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    let mut values = serde_json::to_value(&memories)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .as_array_mut()
+        .map(std::mem::take)
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+    for (memory, value) in memories.iter().zip(&mut values) {
+        let tags = store
+            .get_memory_tags(&memory.id)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        value["tags"] =
+            serde_json::to_value(tags).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    }
+    Ok(axum::Json(serde_json::Value::Array(values)))
 }
 
 #[derive(serde::Deserialize)]
@@ -2436,7 +2689,7 @@ async fn web_decisions(
         .get_decisions(q.project.as_deref(), 100)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(axum::Json(
-        serde_json::to_value(&decisions).unwrap_or_default(),
+        serde_json::to_value(&decisions).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
     ))
 }
 
@@ -2454,7 +2707,7 @@ async fn web_search_sessions(
         .search_sessions_by_summary(&sq.q)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(axum::Json(
-        serde_json::to_value(&sessions).unwrap_or_default(),
+        serde_json::to_value(&sessions).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
     ))
 }
 
@@ -2467,7 +2720,7 @@ async fn web_search_memories(
         .search_memories(&sq.q)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(axum::Json(
-        serde_json::to_value(&memories).unwrap_or_default(),
+        serde_json::to_value(&memories).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
     ))
 }
 
@@ -2487,7 +2740,7 @@ async fn web_facts(
     Query(q): Query<FactsQuery>,
 ) -> Result<axum::Json<serde_json::Value>, StatusCode> {
     let store = state.store()?;
-    let limit = q.limit.unwrap_or(100);
+    let limit = api_limit(q.limit, 100, 10_000);
     let active_only = q.active_only.unwrap_or(true);
     let facts = if active_only {
         store
@@ -2498,7 +2751,9 @@ async fn web_facts(
             .get_all_facts(q.project.as_deref(), limit)
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     };
-    Ok(axum::Json(serde_json::to_value(&facts).unwrap_or_default()))
+    Ok(axum::Json(
+        serde_json::to_value(&facts).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
+    ))
 }
 
 async fn web_fact_history(
@@ -2514,7 +2769,7 @@ async fn web_fact_history(
         .get_fact_history(&fact.subject)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(axum::Json(
-        serde_json::to_value(&history).unwrap_or_default(),
+        serde_json::to_value(&history).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
     ))
 }
 
@@ -2571,7 +2826,7 @@ async fn web_stats_timeline(
     Query(q): Query<TimelineQuery>,
 ) -> Result<axum::Json<serde_json::Value>, StatusCode> {
     let store = state.store()?;
-    let days = q.days.unwrap_or(30);
+    let days = q.days.unwrap_or(30).clamp(1, 365);
     let timeline = store
         .get_session_timeline(days, q.agent.as_deref())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -2599,7 +2854,7 @@ async fn web_hotfiles(
     Query(q): Query<HotFilesQuery>,
 ) -> Result<axum::Json<serde_json::Value>, StatusCode> {
     let store = state.store()?;
-    let limit = q.limit.unwrap_or(20);
+    let limit = api_limit(q.limit, 20, 100);
     let files = store
         .get_hot_files(q.project.as_deref(), limit)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -2615,6 +2870,20 @@ async fn web_hotfiles(
     Ok(axum::Json(serde_json::json!(result)))
 }
 
+async fn web_attention(
+    State(state): State<Arc<WebState>>,
+) -> Result<axum::Json<serde_json::Value>, StatusCode> {
+    let store = state.store()?;
+    let items = store
+        .get_attention_items()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let total = items.len();
+    Ok(axum::Json(serde_json::json!({
+        "items": items,
+        "total": total,
+    })))
+}
+
 async fn web_search_facts(
     State(state): State<Arc<WebState>>,
     Query(sq): Query<SearchQuery>,
@@ -2623,7 +2892,9 @@ async fn web_search_facts(
     let facts = store
         .search_facts(&sq.q)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    Ok(axum::Json(serde_json::to_value(&facts).unwrap_or_default()))
+    Ok(axum::Json(
+        serde_json::to_value(&facts).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
+    ))
 }
 
 #[derive(serde::Deserialize)]
@@ -2637,7 +2908,7 @@ async fn web_search_xpath(
     Query(xq): Query<XPathQuery>,
 ) -> Result<axum::Json<serde_json::Value>, StatusCode> {
     let store = state.store()?;
-    let limit = xq.limit.unwrap_or(20);
+    let limit = api_limit(xq.limit, 20, 500);
 
     let parsed =
         remembrant_engine::xpath_query::parse(&xq.q).map_err(|_| StatusCode::BAD_REQUEST)?;
@@ -2683,7 +2954,7 @@ async fn web_symbols(
     Query(q): Query<SymbolsQuery>,
 ) -> Result<axum::Json<serde_json::Value>, StatusCode> {
     let store = state.store()?;
-    let limit = q.limit.unwrap_or(100);
+    let limit = api_limit(q.limit, 100, 1_000);
     let symbols = if let (Some(file), Some(project)) = (&q.file, &q.project) {
         store
             .get_symbols_in_file(file, project)
@@ -2697,7 +2968,7 @@ async fn web_symbols(
         return Err(StatusCode::BAD_REQUEST);
     };
     Ok(axum::Json(
-        serde_json::to_value(&symbols).unwrap_or_default(),
+        serde_json::to_value(&symbols).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
     ))
 }
 
@@ -2710,7 +2981,7 @@ async fn web_graph_neighbors(
         .query_graph_neighbors(&id, None)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(axum::Json(
-        serde_json::to_value(&neighbors).unwrap_or_default(),
+        serde_json::to_value(&neighbors).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
     ))
 }
 
@@ -2720,6 +2991,7 @@ async fn web_graph_neighbors(
 struct UpdateMemoryBody {
     content: Option<String>,
     confidence: Option<f32>,
+    tags: Option<Vec<String>>,
 }
 
 async fn web_update_memory(
@@ -2728,14 +3000,43 @@ async fn web_update_memory(
     AxumJson(body): AxumJson<UpdateMemoryBody>,
 ) -> Result<axum::Json<serde_json::Value>, StatusCode> {
     let store = state.store()?;
+    if body
+        .content
+        .as_deref()
+        .is_some_and(|content| content.trim().is_empty())
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
     let updated = store
         .update_memory(&id, body.content.as_deref(), body.confidence)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    if updated {
-        Ok(axum::Json(serde_json::json!({"ok": true})))
-    } else {
-        Err(StatusCode::NOT_FOUND)
+    if !updated {
+        return Err(StatusCode::NOT_FOUND);
     }
+
+    if let Some(tags) = &body.tags {
+        store
+            .set_memory_tags(&id, tags)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    }
+    Ok(axum::Json(serde_json::json!({"ok": true})))
+}
+
+async fn web_get_memory(
+    State(state): State<Arc<WebState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<axum::Json<serde_json::Value>, StatusCode> {
+    let store = state.store()?;
+    let memory = store
+        .get_memory(&id)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let tags = store
+        .get_memory_tags(&id)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut value = serde_json::to_value(memory).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    value["tags"] = serde_json::to_value(tags).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(axum::Json(value))
 }
 
 async fn web_delete_memory(
@@ -2772,6 +3073,7 @@ async fn web_delete_fact(
 struct CreateNoteBody {
     text: String,
     project: Option<String>,
+    tags: Option<Vec<String>>,
 }
 
 async fn web_create_note(
@@ -2779,12 +3081,19 @@ async fn web_create_note(
     AxumJson(body): AxumJson<CreateNoteBody>,
 ) -> Result<(StatusCode, axum::Json<serde_json::Value>), StatusCode> {
     let store = state.store()?;
+    if body.text.trim().is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let tags = body.tags.clone().unwrap_or_default();
     let id = store
-        .insert_note(&body.text, body.project.as_deref())
+        .insert_note_with_tags(&body.text, body.project.as_deref(), &tags)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let tags = store
+        .get_memory_tags(&id)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok((
         StatusCode::CREATED,
-        axum::Json(serde_json::json!({"id": id})),
+        axum::Json(serde_json::json!({"id": id, "tags": tags})),
     ))
 }
 
@@ -2801,6 +3110,10 @@ async fn web_create_decision(
     AxumJson(body): AxumJson<CreateDecisionBody>,
 ) -> Result<(StatusCode, axum::Json<serde_json::Value>), StatusCode> {
     use remembrant_engine::store::Decision;
+
+    if body.what.trim().is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
 
     let id = uuid::Uuid::new_v4().to_string();
     let now = chrono::Utc::now().naive_utc();
@@ -2826,16 +3139,197 @@ async fn web_create_decision(
     ))
 }
 
+async fn web_briefing(
+    State(state): State<Arc<WebState>>,
+) -> Result<axum::Json<serde_json::Value>, StatusCode> {
+    let store = state.store()?;
+    let map_store_error = |_| StatusCode::INTERNAL_SERVER_ERROR;
+    let now = chrono::Utc::now().naive_utc();
+    let today_start = now.date().and_hms_opt(0, 0, 0).unwrap_or(now);
+    let yesterday_start = (now - chrono::Duration::days(1))
+        .date()
+        .and_hms_opt(0, 0, 0)
+        .unwrap_or(now);
+
+    // Current (today) counts
+    let cur_sessions = store
+        .count_sessions_since(today_start)
+        .map_err(map_store_error)?;
+    let cur_memories = store
+        .count_memories_since(today_start)
+        .map_err(map_store_error)?;
+    let cur_decisions = store
+        .count_decisions_since(today_start)
+        .map_err(map_store_error)?;
+    let recent_sessions = store
+        .get_recent_sessions_for_briefing()
+        .map_err(map_store_error)?;
+    let cur_tokens: i64 = recent_sessions
+        .iter()
+        .filter(|s| s.started_at.map(|t| t >= today_start).unwrap_or(false))
+        .filter_map(|s| s.total_tokens)
+        .map(|t| t as i64)
+        .sum();
+
+    // Previous (yesterday) counts
+    let prev_sessions = store
+        .count_sessions_since(yesterday_start)
+        .map_err(map_store_error)?
+        .saturating_sub(cur_sessions);
+    let prev_memories = store
+        .count_memories_since(yesterday_start)
+        .map_err(map_store_error)?
+        .saturating_sub(cur_memories);
+    let prev_decisions = store
+        .count_decisions_since(yesterday_start)
+        .map_err(map_store_error)?
+        .saturating_sub(cur_decisions);
+    let prev_tokens: i64 = recent_sessions
+        .iter()
+        .filter(|s| {
+            s.started_at
+                .map(|t| t >= yesterday_start && t < today_start)
+                .unwrap_or(false)
+        })
+        .filter_map(|s| s.total_tokens)
+        .map(|t| t as i64)
+        .sum();
+
+    let trend = |current: f64, previous: f64| -> f64 {
+        if previous == 0.0 {
+            if current > 0.0 { 100.0 } else { 0.0 }
+        } else {
+            ((current - previous) / previous * 100.0 * 10.0).round() / 10.0
+        }
+    };
+
+    // Active agents & projects today
+    let active_agents = store
+        .get_active_agents_since(today_start)
+        .map_err(map_store_error)?;
+    let projects_today: Vec<String> = recent_sessions
+        .iter()
+        .filter(|s| s.started_at.map(|t| t >= today_start).unwrap_or(false))
+        .filter_map(|s| s.project_id.clone())
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    // Headline
+    let sess_trend_pct = trend(cur_sessions as f64, prev_sessions as f64);
+    let trend_word = if sess_trend_pct > 0.0 {
+        format!("up {sess_trend_pct:.0}%")
+    } else if sess_trend_pct < 0.0 {
+        format!("down {:.0}%", sess_trend_pct.abs())
+    } else {
+        "unchanged".to_string()
+    };
+    let headline = format!(
+        "{} made {} session(s) across {} project(s) today, {} from yesterday",
+        if active_agents.is_empty() {
+            "Agents".to_string()
+        } else if active_agents.len() == 1 {
+            active_agents[0].clone()
+        } else {
+            format!("{} agents", active_agents.join(", "))
+        },
+        cur_sessions,
+        projects_today.len(),
+        trend_word,
+    );
+
+    // Sparklines (last 7 days)
+    let spark_sessions = store.get_daily_session_counts(6).map_err(map_store_error)?;
+    let spark_memories = store.get_daily_memory_counts(6).map_err(map_store_error)?;
+    let spark_decisions = store
+        .get_daily_decision_counts(6)
+        .map_err(map_store_error)?;
+
+    // Project breakdown
+    let project_breakdown: Vec<serde_json::Value> = store
+        .get_project_breakdown_today()
+        .map_err(map_store_error)?;
+
+    // Decisions today
+    let decisions_today = store.get_decisions_today().map_err(map_store_error)?;
+
+    // New facts
+    let new_facts = store.get_new_facts_today().map_err(map_store_error)?;
+
+    // Top files
+    let top_files: Vec<serde_json::Value> = store
+        .get_top_files_today(10)
+        .map_err(map_store_error)?
+        .into_iter()
+        .map(|(path, changes)| serde_json::json!({"file_path": path, "change_frequency": changes}))
+        .collect();
+
+    // Session summaries
+    let session_summaries = store
+        .get_session_summaries_today()
+        .map_err(map_store_error)?;
+
+    let date_str = format!(
+        "{}-{:02}-{:02}",
+        now.date().year(),
+        now.date().month(),
+        now.date().day()
+    );
+
+    // Top projects (limited to 5)
+    let top_projects = &project_breakdown[..std::cmp::min(5, project_breakdown.len())];
+
+    Ok(axum::Json(serde_json::json!({
+        "headline": headline,
+        "date": date_str,
+        "period": "today",
+        "metrics": {
+            "sessions": {
+                "current": cur_sessions,
+                "previous": prev_sessions,
+                "trend": trend(cur_sessions as f64, prev_sessions as f64),
+            },
+            "memories": {
+                "current": cur_memories,
+                "previous": prev_memories,
+                "trend": trend(cur_memories as f64, prev_memories as f64),
+            },
+            "decisions": {
+                "current": cur_decisions,
+                "previous": prev_decisions,
+                "trend": trend(cur_decisions as f64, prev_decisions as f64),
+            },
+            "tokens": {
+                "current": cur_tokens,
+                "previous": prev_tokens,
+                "trend": trend(cur_tokens as f64, prev_tokens as f64),
+            },
+        },
+        "sparklines": {
+            "sessions": spark_sessions,
+            "memories": spark_memories,
+            "decisions": spark_decisions,
+        },
+        "active_agents": active_agents,
+        "top_projects": top_projects,
+        "recent_decisions": &decisions_today,
+        "project_breakdown": &project_breakdown,
+        "decisions_today": &decisions_today,
+        "new_facts": new_facts,
+        "top_files": top_files,
+        "session_summaries": session_summaries,
+    })))
+}
+
 fn cmd_mcp() -> Result<()> {
     let config = AppConfig::load()?;
     let db_path = expand_tilde(&config.storage.duckdb_path);
 
     if !db_path.exists() {
-        eprintln!(
+        anyhow::bail!(
             "Database not found at {}. Run 'rem ingest' first.",
             db_path.display()
         );
-        std::process::exit(1);
     }
 
     let store = DuckStore::open(&db_path)?;
@@ -2862,6 +3356,8 @@ async fn cmd_web(port: u16) -> Result<()> {
 
     let app = Router::new()
         .route("/", get(web_index))
+        .route("/assets/dashboard.css", get(web_dashboard_css))
+        .route("/assets/dashboard.js", get(web_dashboard_js))
         .route("/api/stats", get(web_stats))
         .route("/api/projects", get(web_projects))
         .route("/api/sessions", get(web_sessions))
@@ -2880,6 +3376,7 @@ async fn cmd_web(port: u16) -> Result<()> {
         .route("/api/stats/tools", get(web_stats_tools))
         .route("/api/stats/timeline", get(web_stats_timeline))
         .route("/api/hotfiles", get(web_hotfiles))
+        .route("/api/attention", get(web_attention))
         .route("/api/search/facts", get(web_search_facts))
         .route("/api/search/xpath", get(web_search_xpath))
         .route("/api/symbols", get(web_symbols))
@@ -2887,11 +3384,13 @@ async fn cmd_web(port: u16) -> Result<()> {
         // Mutation endpoints
         .route(
             "/api/memories/{id}",
-            put(web_update_memory).delete(web_delete_memory),
+            get(web_get_memory)
+                .put(web_update_memory)
+                .delete(web_delete_memory),
         )
         .route("/api/facts/{id}", delete(web_delete_fact))
         .route("/api/notes", post(web_create_note))
-        .layer(CorsLayer::permissive())
+        .route("/api/briefing", get(web_briefing))
         .with_state(state);
 
     let addr = format!("127.0.0.1:{port}");
@@ -3050,4 +3549,47 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_handles_unicode_and_small_limits() {
+        assert_eq!(truncate("🔐🔐🔐🔐🔐", 4), "🔐...");
+        assert_eq!(truncate("🔐", 1), "🔐");
+        assert_eq!(truncate("unchanged", 20), "unchanged");
+    }
+
+    #[test]
+    fn utc_day_start_uses_midnight_not_rolling_hours() {
+        let timestamp =
+            NaiveDateTime::parse_from_str("2026-08-22 00:00:01", "%Y-%m-%d %H:%M:%S").unwrap();
+        assert_eq!(
+            utc_day_start(timestamp),
+            NaiveDateTime::parse_from_str("2026-08-22 00:00:00", "%Y-%m-%d %H:%M:%S").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_since_accepts_rfc3339_offsets() {
+        let parsed = parse_since("2026-08-21T20:00:00-04:00").unwrap();
+        assert_eq!(
+            parsed,
+            NaiveDateTime::parse_from_str("2026-08-22 00:00:00", "%Y-%m-%d %H:%M:%S").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_since_rejects_out_of_range_relative_values() {
+        assert!(parse_since("999999999999d").is_none());
+    }
+
+    #[test]
+    fn api_limits_are_bounded() {
+        assert_eq!(api_limit(None, 20, 100), 20);
+        assert_eq!(api_limit(Some(0), 20, 100), 1);
+        assert_eq!(api_limit(Some(999), 20, 100), 100);
+    }
 }

--- a/cli/src/mcp_server.rs
+++ b/cli/src/mcp_server.rs
@@ -21,18 +21,35 @@ use remembrant_engine::store::duckdb::{DuckStore, Fact};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+const MCP_PROTOCOL_VERSION: &str = "2026-07-28";
+const LEGACY_MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+const DISCOVER_CACHE_TTL_MS: u64 = 3_600_000;
+const TOOL_LIST_CACHE_TTL_MS: u64 = 300_000;
+const PROTOCOL_VERSION_META_KEY: &str = "io.modelcontextprotocol/protocolVersion";
+const SERVER_INFO_META_KEY: &str = "io.modelcontextprotocol/serverInfo";
+
+fn server_info_meta() -> Value {
+    serde_json::json!({
+        SERVER_INFO_META_KEY: {
+            "name": "remembrant",
+            "version": env!("CARGO_PKG_VERSION"),
+        }
+    })
+}
+
 // ---------------------------------------------------------------------------
 // JSON-RPC 2.0 types
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
 struct JsonRpcRequest {
-    #[allow(dead_code)]
     jsonrpc: String,
     id: Option<Value>,
     method: String,
     #[serde(default)]
     params: Value,
+    #[serde(default)]
+    _meta: Value,
 }
 
 #[derive(Debug, Serialize)]
@@ -49,6 +66,8 @@ struct JsonRpcResponse {
 struct JsonRpcError {
     code: i64,
     message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
 }
 
 // ---------------------------------------------------------------------------
@@ -65,6 +84,9 @@ struct McpTool {
 
 #[derive(Debug, Serialize)]
 struct McpToolResult {
+    #[serde(rename = "resultType")]
+    result_type: &'static str,
+    _meta: Value,
     content: Vec<McpContent>,
     #[serde(rename = "isError", skip_serializing_if = "Option::is_none")]
     is_error: Option<bool>,
@@ -83,6 +105,20 @@ struct McpContent {
 
 pub struct McpServer {
     store: DuckStore,
+}
+
+fn requested_protocol_version(req: &JsonRpcRequest) -> Option<&str> {
+    request_metadata(req)
+        .get(PROTOCOL_VERSION_META_KEY)?
+        .as_str()
+}
+
+/// Return MCP request metadata.
+///
+/// MCP 2026 places `_meta` inside JSON-RPC `params`. Top-level metadata is
+/// accepted as a compatibility fallback for early pre-final clients.
+fn request_metadata(req: &JsonRpcRequest) -> &Value {
+    req.params.get("_meta").unwrap_or(&req._meta)
 }
 
 impl McpServer {
@@ -111,6 +147,7 @@ impl McpServer {
                         error: Some(JsonRpcError {
                             code: -32700,
                             message: format!("Parse error: {e}"),
+                            data: None,
                         }),
                     };
                     writeln!(stdout, "{}", serde_json::to_string(&error_resp)?)?;
@@ -118,6 +155,28 @@ impl McpServer {
                     continue;
                 }
             };
+
+            // JSON-RPC notifications (including legacy MCP `initialized`) have
+            // no `id` and MUST not produce a response.
+            if request.id.is_none() {
+                continue;
+            }
+
+            if request.jsonrpc != "2.0" {
+                let error_resp = JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id: request.id.unwrap_or(Value::Null),
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32600,
+                        message: "Invalid Request: jsonrpc must be \"2.0\"".into(),
+                        data: None,
+                    }),
+                };
+                writeln!(stdout, "{}", serde_json::to_string(&error_resp)?)?;
+                stdout.flush()?;
+                continue;
+            }
 
             let response = self.handle_request(&request);
 
@@ -131,22 +190,65 @@ impl McpServer {
     fn handle_request(&self, req: &JsonRpcRequest) -> JsonRpcResponse {
         let id = req.id.clone().unwrap_or(Value::Null);
 
-        match req.method.as_str() {
-            "initialize" => self.handle_initialize(id),
-            "initialized" => JsonRpcResponse {
+        // Absent top-level `_meta` selects legacy initialize semantics. Once
+        // modern metadata is present, its required MCP fields must be valid.
+        let metadata = request_metadata(req);
+        if !metadata.is_null() {
+            let valid_metadata = metadata.as_object().is_some_and(|metadata| {
+                metadata
+                    .get(PROTOCOL_VERSION_META_KEY)
+                    .is_some_and(Value::is_string)
+                    && metadata
+                        .get("io.modelcontextprotocol/clientCapabilities")
+                        .is_some_and(Value::is_object)
+            });
+            if !valid_metadata {
+                return JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: None,
+                    error: Some(JsonRpcError {
+                        code: -32602,
+                        message: "Invalid modern MCP request metadata".into(),
+                        data: None,
+                    }),
+                };
+            }
+        }
+
+        if let Some(version) = requested_protocol_version(req)
+            && version != MCP_PROTOCOL_VERSION
+        {
+            return JsonRpcResponse {
                 jsonrpc: "2.0",
                 id,
-                result: Some(Value::Null),
-                error: None,
-            },
+                result: None,
+                error: Some(JsonRpcError {
+                    code: -32022,
+                    message: "Unsupported protocol version".into(),
+                    data: Some(serde_json::json!({
+                        "supported": [MCP_PROTOCOL_VERSION],
+                        "requested": version,
+                    })),
+                }),
+            };
+        }
+
+        match req.method.as_str() {
+            "initialize" => self.handle_initialize(id, &req.params),
+            "server/discover" => self.handle_discover(id),
             "tools/list" => self.handle_tools_list(id),
             "tools/call" => self.handle_tools_call(id, &req.params),
-            "ping" => JsonRpcResponse {
-                jsonrpc: "2.0",
-                id,
-                result: Some(Value::Object(serde_json::Map::new())),
-                error: None,
-            },
+            "ping" => {
+                let mut result = serde_json::Map::new();
+                result.insert("resultType".into(), Value::String("complete".into()));
+                JsonRpcResponse {
+                    jsonrpc: "2.0",
+                    id,
+                    result: Some(Value::Object(result)),
+                    error: None,
+                }
+            }
             _ => JsonRpcResponse {
                 jsonrpc: "2.0",
                 id,
@@ -154,6 +256,7 @@ impl McpServer {
                 error: Some(JsonRpcError {
                     code: -32601,
                     message: format!("Method not found: {}", req.method),
+                    data: None,
                 }),
             },
         }
@@ -163,9 +266,22 @@ impl McpServer {
     // Protocol handlers
     // -----------------------------------------------------------------------
 
-    fn handle_initialize(&self, id: Value) -> JsonRpcResponse {
+    fn handle_initialize(&self, id: Value, params: &Value) -> JsonRpcResponse {
+        // Legacy clients select a protocol version during initialize. This
+        // dual-era server keeps support for the original wire shape while all
+        // modern requests use `server/discover` and per-request `_meta`.
+        let requested = params
+            .get("protocolVersion")
+            .and_then(Value::as_str)
+            .unwrap_or(LEGACY_MCP_PROTOCOL_VERSION);
+        let negotiated = if requested == MCP_PROTOCOL_VERSION {
+            MCP_PROTOCOL_VERSION
+        } else {
+            LEGACY_MCP_PROTOCOL_VERSION
+        };
+
         let result = serde_json::json!({
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": negotiated,
             "serverInfo": {
                 "name": "remembrant",
                 "version": env!("CARGO_PKG_VERSION"),
@@ -176,6 +292,31 @@ impl McpServer {
                 },
             },
         });
+
+        JsonRpcResponse {
+            jsonrpc: "2.0",
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    fn handle_discover(&self, id: Value) -> JsonRpcResponse {
+        let mut result = serde_json::json!({
+            "resultType": "complete",
+            "supportedVersions": [MCP_PROTOCOL_VERSION],
+            "capabilities": {
+                "tools": {
+                    "listChanged": false,
+                },
+            },
+            "instructions": "Remembrant provides durable, searchable memory across coding agents. \
+                Use mem_search for broad recall, mem_recall for details, mem_xpath for structured \
+                queries, and mem_decide or mem_add to persist new knowledge.",
+            "ttlMs": DISCOVER_CACHE_TTL_MS,
+            "cacheScope": "public",
+        });
+        result["_meta"] = server_info_meta();
 
         JsonRpcResponse {
             jsonrpc: "2.0",
@@ -409,7 +550,28 @@ impl McpServer {
             },
         ];
 
-        let result = serde_json::json!({ "tools": tools });
+        // Stable ordering and an explicit JSON Schema dialect make the list
+        // deterministic and safely cacheable for MCP 2026 clients.
+        let mut tools = tools;
+        tools.sort_by(|a, b| a.name.cmp(&b.name));
+        for tool in &mut tools {
+            if let Some(schema) = tool.input_schema.as_object_mut()
+                && !schema.contains_key("$schema")
+            {
+                schema.insert(
+                    "$schema".into(),
+                    Value::String("https://json-schema.org/draft/2020-12/schema".into()),
+                );
+            }
+        }
+
+        let result = serde_json::json!({
+            "resultType": "complete",
+            "tools": tools,
+            "ttlMs": TOOL_LIST_CACHE_TTL_MS,
+            "cacheScope": "public",
+            "_meta": server_info_meta(),
+        });
         JsonRpcResponse {
             jsonrpc: "2.0",
             id,
@@ -441,32 +603,60 @@ impl McpServer {
         match result {
             Ok(text) => {
                 let tool_result = McpToolResult {
+                    result_type: "complete",
+                    _meta: server_info_meta(),
                     content: vec![McpContent {
                         content_type: "text".into(),
                         text,
                     }],
                     is_error: None,
                 };
-                JsonRpcResponse {
-                    jsonrpc: "2.0",
-                    id,
-                    result: Some(serde_json::to_value(tool_result).unwrap()),
-                    error: None,
+                match serde_json::to_value(tool_result) {
+                    Ok(value) => JsonRpcResponse {
+                        jsonrpc: "2.0",
+                        id,
+                        result: Some(value),
+                        error: None,
+                    },
+                    Err(error) => JsonRpcResponse {
+                        jsonrpc: "2.0",
+                        id,
+                        result: None,
+                        error: Some(JsonRpcError {
+                            code: -32603,
+                            message: format!("Internal serialization error: {error}"),
+                            data: None,
+                        }),
+                    },
                 }
             }
             Err(e) => {
                 let tool_result = McpToolResult {
+                    result_type: "complete",
+                    _meta: server_info_meta(),
                     content: vec![McpContent {
                         content_type: "text".into(),
                         text: format!("Error: {e}"),
                     }],
                     is_error: Some(true),
                 };
-                JsonRpcResponse {
-                    jsonrpc: "2.0",
-                    id,
-                    result: Some(serde_json::to_value(tool_result).unwrap()),
-                    error: None,
+                match serde_json::to_value(tool_result) {
+                    Ok(value) => JsonRpcResponse {
+                        jsonrpc: "2.0",
+                        id,
+                        result: Some(value),
+                        error: None,
+                    },
+                    Err(error) => JsonRpcResponse {
+                        jsonrpc: "2.0",
+                        id,
+                        result: None,
+                        error: Some(JsonRpcError {
+                            code: -32603,
+                            message: format!("Internal serialization error: {error}"),
+                            data: None,
+                        }),
+                    },
                 }
             }
         }
@@ -587,10 +777,8 @@ impl McpServer {
                     .ok_or_else(|| anyhow::anyhow!("'text' required for notes"))?;
 
                 let id = self.store.insert_note(text, project)?;
-                Ok(format!(
-                    "Note added (id: {id}): {}",
-                    &text[..text.len().min(80)]
-                ))
+                let preview: String = text.chars().take(80).collect();
+                Ok(format!("Note added (id: {id}): {preview}"))
             }
             _ => Err(anyhow::anyhow!(
                 "Unknown type: {entry_type}. Use 'fact' or 'note'."
@@ -665,6 +853,9 @@ impl McpServer {
             .get("what")
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("'what' is required"))?;
+        if what.trim().is_empty() {
+            anyhow::bail!("'what' cannot be empty");
+        }
         let why = args.get("why").and_then(|v| v.as_str());
         let alternatives: Vec<String> = args
             .get("alternatives")
@@ -723,7 +914,7 @@ impl McpServer {
             }
             Ok(format!("Memory {id} updated: {}", parts.join(" and ")))
         } else {
-            Ok(format!("Memory not found: {id}"))
+            anyhow::bail!("Memory not found: {id}")
         }
     }
 
@@ -750,7 +941,7 @@ impl McpServer {
         if deleted {
             Ok(format!("{entry_type} {id} deleted"))
         } else {
-            Ok(format!("{entry_type} not found: {id}"))
+            anyhow::bail!("{entry_type} not found: {id}")
         }
     }
 
@@ -824,5 +1015,149 @@ impl McpServer {
             "Fact revised: '{} {} {}' → '{subject} {predicate} {object}' (old: {old_fact_id}, new: {new_id})",
             old_fact.subject, old_fact.predicate, old_fact.object
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(method: &str, params: Value, modern: bool) -> JsonRpcRequest {
+        let _meta = if modern {
+            serde_json::json!({
+                PROTOCOL_VERSION_META_KEY: MCP_PROTOCOL_VERSION,
+                "io.modelcontextprotocol/clientCapabilities": {},
+            })
+        } else {
+            Value::Object(serde_json::Map::new())
+        };
+        let params = if modern {
+            let mut object = params.as_object().cloned().unwrap_or_default();
+            object.insert("_meta".into(), _meta.clone());
+            Value::Object(object)
+        } else {
+            params
+        };
+
+        JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: Some(Value::from(1)),
+            method: method.into(),
+            params,
+            _meta: Value::Null,
+        }
+    }
+
+    #[test]
+    fn modern_discovery_is_cacheable_and_stateless() {
+        let server = McpServer::new(DuckStore::open_in_memory().expect("store"));
+        let response = server.handle_request(&request("server/discover", Value::Null, true));
+        let result = response.result.expect("discover result");
+
+        assert_eq!(result["resultType"], "complete");
+        assert_eq!(result["supportedVersions"][0], MCP_PROTOCOL_VERSION);
+        assert_eq!(result["ttlMs"], DISCOVER_CACHE_TTL_MS);
+        assert_eq!(result["cacheScope"], "public");
+        assert_eq!(result["_meta"][SERVER_INFO_META_KEY]["name"], "remembrant");
+        assert_eq!(result["capabilities"]["tools"]["listChanged"], false);
+    }
+
+    #[test]
+    fn tools_list_is_deterministic_and_cacheable() {
+        let server = McpServer::new(DuckStore::open_in_memory().expect("store"));
+        let first = server.handle_request(&request("tools/list", Value::Null, true));
+        let second = server.handle_request(&request("tools/list", Value::Null, true));
+        assert_eq!(first.result, second.result);
+
+        let result = first.result.expect("tools result");
+        assert_eq!(result["resultType"], "complete");
+        assert_eq!(result["ttlMs"], TOOL_LIST_CACHE_TTL_MS);
+        assert_eq!(result["cacheScope"], "public");
+        let names: Vec<&str> = result["tools"]
+            .as_array()
+            .expect("tools array")
+            .iter()
+            .filter_map(|tool| tool["name"].as_str())
+            .collect();
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        assert_eq!(names, sorted);
+        assert!(
+            result["tools"]
+                .as_array()
+                .expect("tools array")
+                .iter()
+                .all(|tool| tool["inputSchema"]["$schema"]
+                    .as_str()
+                    .is_some_and(|schema| schema.ends_with("2020-12/schema")))
+        );
+    }
+
+    #[test]
+    fn unsupported_modern_version_returns_supported_versions() {
+        let server = McpServer::new(DuckStore::open_in_memory().expect("store"));
+        let mut req = request("tools/list", Value::Null, true);
+        req.params["_meta"][PROTOCOL_VERSION_META_KEY] = Value::String("1900-01-01".into());
+        let response = server.handle_request(&req);
+
+        let error = response.error.expect("version error");
+        assert_eq!(error.code, -32022);
+        assert_eq!(
+            error.data.expect("version data")["supported"][0],
+            MCP_PROTOCOL_VERSION
+        );
+    }
+
+    #[test]
+    fn malformed_modern_metadata_is_rejected() {
+        let server = McpServer::new(DuckStore::open_in_memory().expect("store"));
+        let mut req = request("tools/list", Value::Null, true);
+        req.params
+            .get_mut("_meta")
+            .and_then(Value::as_object_mut)
+            .expect("metadata object")
+            .remove("io.modelcontextprotocol/clientCapabilities");
+        let response = server.handle_request(&req);
+
+        let error = response.error.expect("metadata error");
+        assert_eq!(error.code, -32602);
+        assert!(error.message.contains("metadata"));
+    }
+
+    #[test]
+    fn legacy_initialize_remains_compatible() {
+        let server = McpServer::new(DuckStore::open_in_memory().expect("store"));
+        let params = serde_json::json!({"protocolVersion": LEGACY_MCP_PROTOCOL_VERSION});
+        let response = server.handle_request(&request("initialize", params, false));
+        let result = response.result.expect("initialize result");
+
+        assert_eq!(result["protocolVersion"], LEGACY_MCP_PROTOCOL_VERSION);
+        assert_eq!(result["serverInfo"]["name"], "remembrant");
+        assert_eq!(result["capabilities"]["tools"]["listChanged"], false);
+    }
+
+    #[test]
+    fn tool_call_add_note_handles_unicode_without_panicking() {
+        let store = DuckStore::open_in_memory().expect("store");
+        let server = McpServer::new(store);
+        let params = serde_json::json!({
+            "name": "mem_add",
+            "arguments": {
+                "type": "note",
+                "text": "🔐 Unicode-safe MCP note",
+                "project": "mcp-tests"
+            }
+        });
+        let response = server.handle_request(&request("tools/call", params, true));
+        let result = response.result.expect("tool result");
+
+        assert_eq!(result["resultType"], "complete");
+        assert_eq!(result["isError"], Value::Null);
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .expect("tool text")
+                .contains("Unicode-safe MCP note")
+        );
     }
 }

--- a/cli/src/web_dashboard.css
+++ b/cli/src/web_dashboard.css
@@ -1,0 +1,420 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap');
+
+        :root {
+            --bg-deep: #0a0e14;
+            --bg-main: #0d1117;
+            --bg-surface: #161b22;
+            --bg-elevated: #1c2333;
+            --bg-hover: #1f2937;
+            --border: #21262d;
+            --border-bright: #30363d;
+            --text-primary: #e6edf3;
+            --text-secondary: #8b949e;
+            --text-dim: #484f58;
+            --accent: #00ff9c;
+            --accent-dim: #00cc7d;
+            --accent-glow: rgba(0, 255, 156, 0.15);
+            --cyan: #79c0ff;
+            --purple: #bc8cff;
+            --orange: #ffa657;
+            --red: #ff7b72;
+            --yellow: #e3b341;
+            --blue: #58a6ff;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: 'JetBrains Mono', 'Menlo', 'Monaco', monospace;
+            background: var(--bg-deep);
+            color: var(--text-primary);
+            line-height: 1.5;
+            font-size: 13px;
+            overflow-x: hidden;
+        }
+
+        .app { display: flex; height: 100vh; }
+
+        /* Sidebar */
+        .sidebar {
+            width: 220px;
+            background: var(--bg-main);
+            border-right: 1px solid var(--border);
+            display: flex;
+            flex-direction: column;
+            flex-shrink: 0;
+        }
+
+        .logo { padding: 20px 16px; border-bottom: 1px solid var(--border); }
+        .logo-text { font-size: 15px; font-weight: 700; color: var(--accent); letter-spacing: 2px; text-transform: uppercase; }
+        .logo-sub { font-size: 10px; color: var(--text-dim); margin-top: 4px; letter-spacing: 1px; }
+        .logo-sub .blink { animation: blink 1s step-end 3; color: var(--accent); }
+        @keyframes blink { 50% { opacity: 0; } }
+
+        .nav { flex: 1; padding: 12px 0; }
+        .nav-item {
+            display: flex; align-items: center; gap: 10px;
+            padding: 10px 16px; cursor: pointer; color: var(--text-secondary);
+            font-size: 12px; transition: all 0.15s; border-left: 2px solid transparent;
+        }
+        .nav-item:hover { background: var(--bg-hover); color: var(--text-primary); }
+        .nav-item.active { color: var(--accent); border-left-color: var(--accent); background: var(--accent-glow); }
+        .nav-icon { font-size: 14px; width: 20px; text-align: center; }
+        .nav-badge {
+            margin-left: auto; background: var(--bg-elevated); color: var(--text-dim);
+            padding: 1px 6px; border-radius: 3px; font-size: 10px;
+        }
+        .nav-item.active .nav-badge { background: rgba(0,255,156,0.1); color: var(--accent); }
+        .nav-sep { height: 1px; background: var(--border); margin: 8px 16px; }
+
+        .sidebar-footer { padding: 12px 16px; border-top: 1px solid var(--border); font-size: 10px; color: var(--text-dim); }
+        .status-dot {
+            display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+            background: var(--accent); box-shadow: 0 0 6px var(--accent);
+            margin-right: 6px; animation: pulse 2s ease-in-out infinite;
+        }
+        @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+        /* Main */
+        .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+
+        /* Topbar */
+        .topbar {
+            display: flex; align-items: center; gap: 10px;
+            padding: 10px 24px; background: var(--bg-main); border-bottom: 1px solid var(--border);
+            flex-wrap: wrap;
+        }
+        .search-wrapper { flex: 1; position: relative; min-width: 200px; }
+        .search-prefix { position: absolute; left: 12px; top: 50%; transform: translateY(-50%); color: var(--accent); font-size: 12px; pointer-events: none; }
+        .search-input {
+            width: 100%; background: var(--bg-surface); border: 1px solid var(--border);
+            color: var(--text-primary); padding: 8px 12px 8px 28px; border-radius: 6px;
+            font-family: inherit; font-size: 12px; transition: border-color 0.2s;
+        }
+        .search-input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent-glow); }
+        .search-input::placeholder { color: var(--text-dim); }
+
+        .search-modes { display: flex; gap: 4px; }
+        .mode-btn {
+            background: var(--bg-surface); border: 1px solid var(--border); color: var(--text-dim);
+            padding: 6px 10px; border-radius: 4px; cursor: pointer; font-family: inherit; font-size: 10px;
+            text-transform: uppercase; letter-spacing: 0.5px; transition: all 0.15s;
+        }
+        .mode-btn:hover { border-color: var(--text-dim); color: var(--text-secondary); }
+        .mode-btn.active { border-color: var(--accent); color: var(--accent); background: var(--accent-glow); }
+
+        .filter-chips { display: flex; gap: 4px; }
+        .chip {
+            padding: 5px 10px; border-radius: 4px; cursor: pointer; font-family: inherit;
+            font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;
+            border: 1px solid transparent; transition: all 0.15s; opacity: 0.5;
+        }
+        .chip.active { opacity: 1; }
+        .chip-claude { background: rgba(88,166,255,0.15); color: var(--blue); border-color: rgba(88,166,255,0.3); }
+        .chip-codex { background: rgba(0,255,156,0.1); color: var(--accent); border-color: rgba(0,255,156,0.2); }
+        .chip-gemini { background: rgba(188,140,255,0.15); color: var(--purple); border-color: rgba(188,140,255,0.3); }
+
+        .date-select, .filter-select {
+            background: var(--bg-surface); border: 1px solid var(--border); color: var(--text-secondary);
+            padding: 7px 10px; border-radius: 6px; font-family: inherit; font-size: 11px; cursor: pointer;
+        }
+        .date-select:focus, .filter-select:focus { outline: none; border-color: var(--accent); }
+
+        .btn {
+            background: var(--accent); color: var(--bg-deep); border: none; padding: 8px 14px;
+            border-radius: 6px; cursor: pointer; font-family: inherit; font-weight: 600;
+            font-size: 11px; transition: all 0.15s;
+        }
+        .btn:hover { box-shadow: 0 0 12px var(--accent-glow); filter: brightness(1.1); }
+        .btn-ghost { background: transparent; border: 1px solid var(--border); color: var(--text-secondary); }
+        .btn-ghost:hover { border-color: var(--text-dim); color: var(--text-primary); box-shadow: none; }
+        .btn-sm { padding: 4px 8px; font-size: 10px; }
+        .btn-danger { background: var(--red); }
+        .btn-danger:hover { box-shadow: 0 0 12px rgba(255,123,114,0.3); }
+
+        /* Content */
+        .content { flex: 1; overflow-y: auto; padding: 20px 24px; }
+        .content::-webkit-scrollbar { width: 6px; }
+        .content::-webkit-scrollbar-track { background: transparent; }
+        .content::-webkit-scrollbar-thumb { background: var(--border-bright); border-radius: 3px; }
+
+        /* Stats grid */
+        .stats-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; margin-bottom: 20px; }
+        .stat-card {
+            background: var(--bg-surface); border: 1px solid var(--border);
+            border-radius: 8px; padding: 14px; position: relative; overflow: hidden;
+        }
+        .stat-card::before {
+            content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+            background: linear-gradient(90deg, var(--accent), transparent); opacity: 0.6;
+        }
+        .stat-label { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 1.5px; margin-bottom: 4px; }
+        .stat-value { font-size: 22px; font-weight: 700; color: var(--text-primary); }
+
+        /* Panels */
+        .panel { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 16px; }
+        .panel-header { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; border-bottom: 1px solid var(--border); }
+        .panel-title { font-size: 12px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 1px; }
+        .panel-title .count { color: var(--text-dim); font-weight: 400; }
+
+        /* Tables */
+        table { width: 100%; border-collapse: collapse; }
+        th {
+            text-align: left; padding: 8px 14px; font-size: 10px; font-weight: 600;
+            color: var(--text-dim); text-transform: uppercase; letter-spacing: 1px;
+            cursor: pointer; user-select: none; background: var(--bg-elevated); border-bottom: 1px solid var(--border);
+        }
+        th:hover { color: var(--accent); }
+        td { padding: 8px 14px; border-bottom: 1px solid var(--border); font-size: 12px; }
+        tr:last-child td { border-bottom: none; }
+        tbody tr { transition: background 0.1s; }
+        tbody tr:hover { background: var(--bg-hover); cursor: pointer; }
+
+        .agent-tag { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+        .agent-claude, .agent-claude_code { background: rgba(88,166,255,0.15); color: var(--blue); border: 1px solid rgba(88,166,255,0.2); }
+        .agent-codex { background: rgba(0,255,156,0.1); color: var(--accent); border: 1px solid rgba(0,255,156,0.15); }
+        .agent-gemini { background: rgba(188,140,255,0.15); color: var(--purple); border: 1px solid rgba(188,140,255,0.2); }
+
+        .truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 400px; }
+        .dim { color: var(--text-dim); }
+        .mono { font-variant-numeric: tabular-nums; }
+
+        /* Confidence bar */
+        .conf-bar { display: inline-flex; align-items: center; gap: 6px; }
+        .conf-track { width: 40px; height: 4px; background: var(--bg-hover); border-radius: 2px; overflow: hidden; }
+        .conf-fill { height: 100%; border-radius: 2px; }
+        .conf-high { background: var(--accent); }
+        .conf-mid { background: var(--yellow); }
+        .conf-low { background: var(--red); }
+
+        /* Cards */
+        .card-list { padding: 8px; }
+        .memory-card {
+            background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 6px;
+            padding: 12px 14px; margin-bottom: 8px; border-left: 2px solid var(--accent); transition: border-color 0.15s;
+        }
+        .memory-card:hover { border-left-color: var(--cyan); }
+        .card-meta { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
+        .card-type { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; color: var(--accent); }
+        .card-date { font-size: 10px; color: var(--text-dim); }
+        .card-body { font-size: 12px; color: var(--text-secondary); line-height: 1.6; }
+        .card-footer { font-size: 10px; color: var(--text-dim); margin-top: 6px; }
+        .card-actions { display: flex; gap: 6px; }
+        .card-actions button {
+            background: none; border: 1px solid var(--border); color: var(--text-dim); border-radius: 3px;
+            padding: 2px 6px; cursor: pointer; font-family: inherit; font-size: 10px; transition: all 0.15s;
+        }
+        .card-actions button:hover { border-color: var(--text-secondary); color: var(--text-primary); }
+        .card-actions button.del:hover { border-color: var(--red); color: var(--red); }
+
+        .decision-card {
+            background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 6px;
+            padding: 12px 14px; margin-bottom: 8px; border-left: 2px solid var(--purple);
+        }
+        .decision-card:hover { border-left-color: var(--orange); }
+        .decision-card .card-type { color: var(--purple); }
+
+        /* Fact styling */
+        .fact-superseded { opacity: 0.5; text-decoration: line-through; }
+        .fact-active .status-badge { background: rgba(0,255,156,0.1); color: var(--accent); }
+        .fact-inactive .status-badge { background: rgba(139,148,158,0.1); color: var(--text-dim); }
+        .status-badge { display: inline-block; padding: 1px 6px; border-radius: 3px; font-size: 9px; font-weight: 600; text-transform: uppercase; }
+
+        /* Timeline */
+        .timeline { padding: 8px 16px; }
+        .timeline-item { display: flex; gap: 12px; padding: 8px 0; border-left: 2px solid var(--border); margin-left: 8px; padding-left: 16px; position: relative; }
+        .timeline-item::before { content: ''; position: absolute; left: -5px; top: 12px; width: 8px; height: 8px; border-radius: 50%; background: var(--accent); border: 2px solid var(--bg-surface); }
+        .timeline-item.superseded::before { background: var(--text-dim); }
+        .timeline-meta { flex-shrink: 0; width: 120px; font-size: 10px; color: var(--text-dim); }
+        .timeline-content { flex: 1; font-size: 12px; }
+        .timeline-diff-add { color: var(--accent); }
+        .timeline-diff-del { color: var(--red); text-decoration: line-through; }
+
+        /* Charts */
+        .chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 16px; }
+        .chart-card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
+        .chart-card h3 { font-size: 11px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
+        .chart-container { position: relative; height: 220px; }
+        .chart-card.full { grid-column: 1 / -1; }
+
+        /* Analytics metric cards */
+        .metric-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px; }
+        .metric-card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; }
+        .metric-agent { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 6px; }
+        .metric-val { font-size: 20px; font-weight: 700; }
+        .metric-label { font-size: 10px; color: var(--text-dim); margin-top: 2px; }
+
+        /* Modal */
+        .modal-overlay {
+            display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+            background: rgba(0,0,0,0.85); z-index: 1000; padding: 40px; overflow-y: auto;
+        }
+        .modal { background: var(--bg-surface); border: 1px solid var(--border); max-width: 900px; margin: 0 auto; border-radius: 8px; overflow: hidden; }
+        .modal-header { display: flex; justify-content: space-between; align-items: center; padding: 14px 20px; background: var(--bg-elevated); border-bottom: 1px solid var(--border); }
+        .modal-header h2 { font-size: 14px; font-weight: 600; color: var(--text-primary); }
+        .modal-close { background: none; border: none; color: var(--text-dim); font-size: 20px; cursor: pointer; padding: 0 4px; }
+        .modal-close:hover { color: var(--red); }
+        .modal-body { padding: 20px; }
+        .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 24px; margin-bottom: 16px; }
+        .detail-item label { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 1px; }
+        .detail-item .val { font-size: 13px; color: var(--text-primary); margin-top: 2px; }
+
+        .tool-call-item {
+            background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 4px;
+            padding: 8px 12px; margin-bottom: 4px; border-left: 2px solid var(--cyan); font-size: 12px;
+        }
+        .tool-call-item.failed { border-left-color: var(--red); }
+        .tool-call-item .tc-header { display: flex; justify-content: space-between; color: var(--text-primary); font-weight: 500; }
+        .tool-call-item .tc-cmd { color: var(--text-dim); margin-top: 3px; font-size: 11px; word-break: break-all; }
+        .tool-call-item .tc-err { color: var(--red); margin-top: 3px; font-size: 11px; }
+
+        .files-list { list-style: none; padding: 0; }
+        .files-list li { padding: 3px 0; font-size: 12px; color: var(--cyan); }
+        .files-list li::before { content: '\2192 '; color: var(--text-dim); }
+
+        /* Command palette */
+        .cmd-overlay {
+            display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+            background: rgba(0,0,0,0.7); z-index: 2000; padding: 20vh 0 0;
+        }
+        .cmd-dialog {
+            max-width: 560px; margin: 0 auto; background: var(--bg-surface); border: 1px solid var(--border);
+            border-radius: 10px; overflow: hidden; box-shadow: 0 16px 40px rgba(0,0,0,0.5);
+        }
+        .cmd-input {
+            width: 100%; background: transparent; border: none; border-bottom: 1px solid var(--border);
+            color: var(--text-primary); padding: 16px 20px; font-family: inherit; font-size: 14px;
+        }
+        .cmd-input:focus { outline: none; }
+        .cmd-input::placeholder { color: var(--text-dim); }
+        .cmd-results { max-height: 300px; overflow-y: auto; }
+        .cmd-item {
+            padding: 10px 20px; cursor: pointer; display: flex; align-items: center; gap: 10px;
+            font-size: 13px; color: var(--text-secondary); transition: background 0.1s;
+        }
+        .cmd-item:hover, .cmd-item.selected { background: var(--accent-glow); color: var(--accent); }
+        .cmd-item .cmd-icon { width: 20px; text-align: center; font-size: 14px; }
+        .cmd-hint { margin-left: auto; font-size: 10px; color: var(--text-dim); }
+
+        /* Inline edit form */
+        .edit-form { background: var(--bg-deep); border: 1px solid var(--border); border-radius: 6px; padding: 12px; margin-top: 8px; }
+        .edit-form textarea {
+            width: 100%; background: var(--bg-surface); border: 1px solid var(--border); color: var(--text-primary);
+            padding: 8px; border-radius: 4px; font-family: inherit; font-size: 12px; resize: vertical; min-height: 60px;
+        }
+        .edit-form textarea:focus { outline: none; border-color: var(--accent); }
+        .edit-form .edit-row { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
+        .edit-form input[type=range] { flex: 1; accent-color: var(--accent); }
+
+        .empty-state { text-align: center; padding: 48px 24px; color: var(--text-dim); }
+        .empty-state .empty-icon { font-size: 40px; margin-bottom: 16px; opacity: 0.5; }
+        .empty-state .empty-title { font-size: 14px; font-weight: 600; color: var(--text-secondary); margin-bottom: 8px; }
+        .empty-state .empty-desc { font-size: 12px; color: var(--text-dim); line-height: 1.6; margin-bottom: 16px; max-width: 400px; margin-left: auto; margin-right: auto; }
+        .empty-state .empty-commands { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 6px; padding: 12px 16px; display: inline-block; text-align: left; font-size: 11px; line-height: 1.8; }
+        .empty-state .empty-commands code { color: var(--accent); }
+        .empty-state .empty-commands .cmd-comment { color: var(--text-dim); }
+
+        .loading-state { text-align: center; padding: 40px; color: var(--accent); font-size: 12px; }
+        .loading-state::after { content: '...'; animation: dots 1.5s steps(4, end) infinite; }
+        @keyframes dots { 0%,20% { content: ''; } 40% { content: '.'; } 60% { content: '..'; } 80%,100% { content: '...'; } }
+
+        .tab-content { display: none; }
+        .tab-content.active { display: block; }
+
+        .statusbar {
+            display: flex; align-items: center; gap: 16px;
+            padding: 6px 24px; background: var(--bg-main); border-top: 1px solid var(--border);
+            font-size: 10px; color: var(--text-dim);
+        }
+        .statusbar .sep { width: 1px; height: 10px; background: var(--border); }
+
+        .section-label { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 1.5px; padding: 12px 14px 6px; }
+
+        .kbd { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 3px; padding: 1px 5px; font-size: 10px; color: var(--text-dim); }
+
+        /* Briefing hero */
+        .briefing-hero {
+            background: linear-gradient(135deg, var(--bg-surface) 0%, var(--bg-elevated) 100%);
+            border: 1px solid var(--border); border-radius: 10px;
+            padding: 20px 24px; margin-bottom: 16px; position: relative; overflow: hidden;
+        }
+        .briefing-hero::before {
+            content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+            background: linear-gradient(90deg, var(--accent), var(--cyan), var(--purple)); opacity: 0.8;
+        }
+        .briefing-headline {
+            font-size: 16px; font-weight: 300; color: var(--text-primary); line-height: 1.5; margin-bottom: 12px;
+        }
+        .briefing-headline strong { font-weight: 600; color: var(--accent); }
+        .briefing-metrics { display: flex; gap: 24px; flex-wrap: wrap; }
+        .briefing-metric { display: flex; flex-direction: column; gap: 2px; }
+        .briefing-metric-value { font-size: 20px; font-weight: 700; color: var(--text-primary); display: flex; align-items: center; gap: 6px; }
+        .briefing-metric-label { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 1px; }
+
+        /* Trend indicators */
+        .trend { font-size: 11px; font-weight: 600; }
+        .trend-up { color: var(--accent); }
+        .trend-down { color: var(--red); }
+        .trend-flat { color: var(--text-dim); }
+
+        /* Sparklines */
+        .sparkline { display: inline-block; vertical-align: middle; margin-left: 6px; }
+        .sparkline svg { display: block; }
+        .stat-card { display: flex; flex-direction: column; justify-content: space-between; }
+        .stat-row { display: flex; align-items: flex-end; justify-content: space-between; }
+
+        /* Activity feed */
+        .activity-feed { padding: 0; }
+        .feed-item {
+            display: flex; gap: 14px; padding: 12px 16px;
+            border-bottom: 1px solid var(--border); transition: background 0.1s; cursor: pointer;
+        }
+        .feed-item:last-child { border-bottom: none; }
+        .feed-item:hover { background: var(--bg-hover); }
+        .feed-icon { width: 32px; height: 32px; border-radius: 6px; display: flex; align-items: center; justify-content: center; font-size: 14px; flex-shrink: 0; }
+        .feed-icon-claude, .feed-icon-claude_code { background: rgba(88,166,255,0.15); color: var(--blue); }
+        .feed-icon-codex { background: rgba(0,255,156,0.1); color: var(--accent); }
+        .feed-icon-gemini { background: rgba(188,140,255,0.15); color: var(--purple); }
+        .feed-body { flex: 1; min-width: 0; }
+        .feed-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 3px; }
+        .feed-agent { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+        .feed-time { font-size: 10px; color: var(--text-dim); }
+        .feed-summary { font-size: 12px; color: var(--text-secondary); line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+        .feed-meta { display: flex; gap: 12px; margin-top: 4px; font-size: 10px; color: var(--text-dim); }
+        .feed-meta span { display: flex; align-items: center; gap: 3px; }
+        .feed-day-header {
+            padding: 8px 16px; font-size: 10px; font-weight: 600; color: var(--text-dim);
+            text-transform: uppercase; letter-spacing: 1.5px; background: var(--bg-deep);
+            border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 1;
+        }
+        .feed-detail { padding: 12px 16px; background: var(--bg-deep); border-bottom: 1px solid var(--border); display: none; }
+        .feed-item.expanded + .feed-detail { display: block; }
+
+        /* Attention items */
+        .attention-bar {
+            display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px;
+        }
+        .attention-item {
+            background: var(--bg-surface); border: 1px solid var(--border);
+            border-radius: 8px; padding: 10px 14px;
+            border-left: 3px solid var(--yellow); cursor: default; transition: border-color 0.15s;
+        }
+        .attention-item:hover { border-color: var(--border-bright); }
+        .attention-item.severity-high { border-left-color: var(--red); }
+        .attention-item.severity-medium { border-left-color: var(--yellow); }
+        .attention-item.severity-low { border-left-color: var(--text-dim); }
+        .attention-type { font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 4px; }
+        .attention-type.type-conflict { color: var(--red); }
+        .attention-type.type-stale_memory { color: var(--yellow); }
+        .attention-type.type-high_churn { color: var(--orange); }
+        .attention-type.type-contradictory_fact { color: var(--purple); }
+        .attention-title { font-size: 12px; color: var(--text-primary); font-weight: 500; margin-bottom: 2px; }
+        .attention-detail { font-size: 10px; color: var(--text-dim); line-height: 1.4; }
+
+        /* Morning briefing digest */
+        .digest-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 14px; }
+        .digest-card { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 6px; padding: 12px 14px; }
+        .digest-card-title { font-size: 10px; font-weight: 600; color: var(--text-dim); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px; }
+        .digest-list { list-style: none; padding: 0; }
+        .digest-list li { font-size: 11px; color: var(--text-secondary); padding: 3px 0; line-height: 1.5; }
+        .digest-list li::before { content: '\203A '; color: var(--accent); margin-right: 4px; }

--- a/cli/src/web_dashboard.html
+++ b/cli/src/web_dashboard.html
@@ -4,348 +4,22 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Remembrant</title>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap');
-
-        :root {
-            --bg-deep: #0a0e14;
-            --bg-main: #0d1117;
-            --bg-surface: #161b22;
-            --bg-elevated: #1c2333;
-            --bg-hover: #1f2937;
-            --border: #21262d;
-            --border-bright: #30363d;
-            --text-primary: #e6edf3;
-            --text-secondary: #8b949e;
-            --text-dim: #484f58;
-            --accent: #00ff9c;
-            --accent-dim: #00cc7d;
-            --accent-glow: rgba(0, 255, 156, 0.15);
-            --cyan: #79c0ff;
-            --purple: #bc8cff;
-            --orange: #ffa657;
-            --red: #ff7b72;
-            --yellow: #e3b341;
-            --blue: #58a6ff;
-        }
-
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-
-        body {
-            font-family: 'JetBrains Mono', 'Menlo', 'Monaco', monospace;
-            background: var(--bg-deep);
-            color: var(--text-primary);
-            line-height: 1.5;
-            font-size: 13px;
-            overflow-x: hidden;
-        }
-
-        body::after {
-            content: '';
-            position: fixed;
-            top: 0; left: 0; right: 0; bottom: 0;
-            background: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.03) 2px, rgba(0,0,0,0.03) 4px);
-            pointer-events: none;
-            z-index: 9999;
-        }
-
-        .app { display: flex; height: 100vh; }
-
-        /* Sidebar */
-        .sidebar {
-            width: 220px;
-            background: var(--bg-main);
-            border-right: 1px solid var(--border);
-            display: flex;
-            flex-direction: column;
-            flex-shrink: 0;
-        }
-
-        .logo { padding: 20px 16px; border-bottom: 1px solid var(--border); }
-        .logo-text { font-size: 15px; font-weight: 700; color: var(--accent); letter-spacing: 2px; text-transform: uppercase; }
-        .logo-sub { font-size: 10px; color: var(--text-dim); margin-top: 4px; letter-spacing: 1px; }
-        .logo-sub .blink { animation: blink 1s step-end infinite; color: var(--accent); }
-        @keyframes blink { 50% { opacity: 0; } }
-
-        .nav { flex: 1; padding: 12px 0; }
-        .nav-item {
-            display: flex; align-items: center; gap: 10px;
-            padding: 10px 16px; cursor: pointer; color: var(--text-secondary);
-            font-size: 12px; transition: all 0.15s; border-left: 2px solid transparent;
-        }
-        .nav-item:hover { background: var(--bg-hover); color: var(--text-primary); }
-        .nav-item.active { color: var(--accent); border-left-color: var(--accent); background: var(--accent-glow); }
-        .nav-icon { font-size: 14px; width: 20px; text-align: center; }
-        .nav-badge {
-            margin-left: auto; background: var(--bg-elevated); color: var(--text-dim);
-            padding: 1px 6px; border-radius: 3px; font-size: 10px;
-        }
-        .nav-item.active .nav-badge { background: rgba(0,255,156,0.1); color: var(--accent); }
-        .nav-sep { height: 1px; background: var(--border); margin: 8px 16px; }
-
-        .sidebar-footer { padding: 12px 16px; border-top: 1px solid var(--border); font-size: 10px; color: var(--text-dim); }
-        .status-dot {
-            display: inline-block; width: 6px; height: 6px; border-radius: 50%;
-            background: var(--accent); box-shadow: 0 0 6px var(--accent);
-            margin-right: 6px; animation: pulse 2s ease-in-out infinite;
-        }
-        @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-
-        /* Main */
-        .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
-
-        /* Topbar */
-        .topbar {
-            display: flex; align-items: center; gap: 10px;
-            padding: 10px 24px; background: var(--bg-main); border-bottom: 1px solid var(--border);
-            flex-wrap: wrap;
-        }
-        .search-wrapper { flex: 1; position: relative; min-width: 200px; }
-        .search-prefix { position: absolute; left: 12px; top: 50%; transform: translateY(-50%); color: var(--accent); font-size: 12px; pointer-events: none; }
-        .search-input {
-            width: 100%; background: var(--bg-surface); border: 1px solid var(--border);
-            color: var(--text-primary); padding: 8px 12px 8px 28px; border-radius: 6px;
-            font-family: inherit; font-size: 12px; transition: border-color 0.2s;
-        }
-        .search-input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent-glow); }
-        .search-input::placeholder { color: var(--text-dim); }
-
-        .search-modes { display: flex; gap: 4px; }
-        .mode-btn {
-            background: var(--bg-surface); border: 1px solid var(--border); color: var(--text-dim);
-            padding: 6px 10px; border-radius: 4px; cursor: pointer; font-family: inherit; font-size: 10px;
-            text-transform: uppercase; letter-spacing: 0.5px; transition: all 0.15s;
-        }
-        .mode-btn:hover { border-color: var(--text-dim); color: var(--text-secondary); }
-        .mode-btn.active { border-color: var(--accent); color: var(--accent); background: var(--accent-glow); }
-
-        .filter-chips { display: flex; gap: 4px; }
-        .chip {
-            padding: 5px 10px; border-radius: 4px; cursor: pointer; font-family: inherit;
-            font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;
-            border: 1px solid transparent; transition: all 0.15s; opacity: 0.5;
-        }
-        .chip.active { opacity: 1; }
-        .chip-claude { background: rgba(88,166,255,0.15); color: var(--blue); border-color: rgba(88,166,255,0.3); }
-        .chip-codex { background: rgba(0,255,156,0.1); color: var(--accent); border-color: rgba(0,255,156,0.2); }
-        .chip-gemini { background: rgba(188,140,255,0.15); color: var(--purple); border-color: rgba(188,140,255,0.3); }
-
-        .date-select, .filter-select {
-            background: var(--bg-surface); border: 1px solid var(--border); color: var(--text-secondary);
-            padding: 7px 10px; border-radius: 6px; font-family: inherit; font-size: 11px; cursor: pointer;
-        }
-        .date-select:focus, .filter-select:focus { outline: none; border-color: var(--accent); }
-
-        .btn {
-            background: var(--accent); color: var(--bg-deep); border: none; padding: 8px 14px;
-            border-radius: 6px; cursor: pointer; font-family: inherit; font-weight: 600;
-            font-size: 11px; transition: all 0.15s;
-        }
-        .btn:hover { box-shadow: 0 0 12px var(--accent-glow); filter: brightness(1.1); }
-        .btn-ghost { background: transparent; border: 1px solid var(--border); color: var(--text-secondary); }
-        .btn-ghost:hover { border-color: var(--text-dim); color: var(--text-primary); box-shadow: none; }
-        .btn-sm { padding: 4px 8px; font-size: 10px; }
-        .btn-danger { background: var(--red); }
-        .btn-danger:hover { box-shadow: 0 0 12px rgba(255,123,114,0.3); }
-
-        /* Content */
-        .content { flex: 1; overflow-y: auto; padding: 20px 24px; }
-        .content::-webkit-scrollbar { width: 6px; }
-        .content::-webkit-scrollbar-track { background: transparent; }
-        .content::-webkit-scrollbar-thumb { background: var(--border-bright); border-radius: 3px; }
-
-        /* Stats grid */
-        .stats-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; margin-bottom: 20px; }
-        .stat-card {
-            background: var(--bg-surface); border: 1px solid var(--border);
-            border-radius: 8px; padding: 14px; position: relative; overflow: hidden;
-        }
-        .stat-card::before {
-            content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
-            background: linear-gradient(90deg, var(--accent), transparent); opacity: 0.6;
-        }
-        .stat-label { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 1.5px; margin-bottom: 4px; }
-        .stat-value { font-size: 22px; font-weight: 700; color: var(--text-primary); }
-
-        /* Panels */
-        .panel { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 16px; }
-        .panel-header { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; border-bottom: 1px solid var(--border); }
-        .panel-title { font-size: 12px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 1px; }
-        .panel-title .count { color: var(--text-dim); font-weight: 400; }
-
-        /* Tables */
-        table { width: 100%; border-collapse: collapse; }
-        th {
-            text-align: left; padding: 8px 14px; font-size: 10px; font-weight: 600;
-            color: var(--text-dim); text-transform: uppercase; letter-spacing: 1px;
-            cursor: pointer; user-select: none; background: var(--bg-elevated); border-bottom: 1px solid var(--border);
-        }
-        th:hover { color: var(--accent); }
-        td { padding: 8px 14px; border-bottom: 1px solid var(--border); font-size: 12px; }
-        tr:last-child td { border-bottom: none; }
-        tbody tr { transition: background 0.1s; }
-        tbody tr:hover { background: var(--bg-hover); cursor: pointer; }
-
-        .agent-tag { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
-        .agent-claude { background: rgba(88,166,255,0.15); color: var(--blue); border: 1px solid rgba(88,166,255,0.2); }
-        .agent-codex { background: rgba(0,255,156,0.1); color: var(--accent); border: 1px solid rgba(0,255,156,0.15); }
-        .agent-gemini { background: rgba(188,140,255,0.15); color: var(--purple); border: 1px solid rgba(188,140,255,0.2); }
-
-        .truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 400px; }
-        .dim { color: var(--text-dim); }
-        .mono { font-variant-numeric: tabular-nums; }
-
-        /* Confidence bar */
-        .conf-bar { display: inline-flex; align-items: center; gap: 6px; }
-        .conf-track { width: 40px; height: 4px; background: var(--bg-hover); border-radius: 2px; overflow: hidden; }
-        .conf-fill { height: 100%; border-radius: 2px; }
-        .conf-high { background: var(--accent); }
-        .conf-mid { background: var(--yellow); }
-        .conf-low { background: var(--red); }
-
-        /* Cards */
-        .card-list { padding: 8px; }
-        .memory-card {
-            background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 6px;
-            padding: 12px 14px; margin-bottom: 8px; border-left: 2px solid var(--accent); transition: border-color 0.15s;
-        }
-        .memory-card:hover { border-left-color: var(--cyan); }
-        .card-meta { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
-        .card-type { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; color: var(--accent); }
-        .card-date { font-size: 10px; color: var(--text-dim); }
-        .card-body { font-size: 12px; color: var(--text-secondary); line-height: 1.6; }
-        .card-footer { font-size: 10px; color: var(--text-dim); margin-top: 6px; }
-        .card-actions { display: flex; gap: 6px; }
-        .card-actions button {
-            background: none; border: 1px solid var(--border); color: var(--text-dim); border-radius: 3px;
-            padding: 2px 6px; cursor: pointer; font-family: inherit; font-size: 10px; transition: all 0.15s;
-        }
-        .card-actions button:hover { border-color: var(--text-secondary); color: var(--text-primary); }
-        .card-actions button.del:hover { border-color: var(--red); color: var(--red); }
-
-        .decision-card {
-            background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 6px;
-            padding: 12px 14px; margin-bottom: 8px; border-left: 2px solid var(--purple);
-        }
-        .decision-card:hover { border-left-color: var(--orange); }
-        .decision-card .card-type { color: var(--purple); }
-
-        /* Fact styling */
-        .fact-superseded { opacity: 0.5; text-decoration: line-through; }
-        .fact-active .status-badge { background: rgba(0,255,156,0.1); color: var(--accent); }
-        .fact-inactive .status-badge { background: rgba(139,148,158,0.1); color: var(--text-dim); }
-        .status-badge { display: inline-block; padding: 1px 6px; border-radius: 3px; font-size: 9px; font-weight: 600; text-transform: uppercase; }
-
-        /* Timeline */
-        .timeline { padding: 8px 16px; }
-        .timeline-item { display: flex; gap: 12px; padding: 8px 0; border-left: 2px solid var(--border); margin-left: 8px; padding-left: 16px; position: relative; }
-        .timeline-item::before { content: ''; position: absolute; left: -5px; top: 12px; width: 8px; height: 8px; border-radius: 50%; background: var(--accent); border: 2px solid var(--bg-surface); }
-        .timeline-item.superseded::before { background: var(--text-dim); }
-        .timeline-meta { flex-shrink: 0; width: 120px; font-size: 10px; color: var(--text-dim); }
-        .timeline-content { flex: 1; font-size: 12px; }
-        .timeline-diff-add { color: var(--accent); }
-        .timeline-diff-del { color: var(--red); text-decoration: line-through; }
-
-        /* Charts */
-        .chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 16px; }
-        .chart-card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
-        .chart-card h3 { font-size: 11px; font-weight: 600; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 1px; margin-bottom: 12px; }
-        .chart-container { position: relative; height: 220px; }
-        .chart-card.full { grid-column: 1 / -1; }
-
-        /* Analytics metric cards */
-        .metric-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 16px; }
-        .metric-card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; }
-        .metric-agent { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 6px; }
-        .metric-val { font-size: 20px; font-weight: 700; }
-        .metric-label { font-size: 10px; color: var(--text-dim); margin-top: 2px; }
-
-        /* Modal */
-        .modal-overlay {
-            display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0;
-            background: rgba(0,0,0,0.85); z-index: 1000; padding: 40px; overflow-y: auto;
-        }
-        .modal { background: var(--bg-surface); border: 1px solid var(--border); max-width: 900px; margin: 0 auto; border-radius: 8px; overflow: hidden; }
-        .modal-header { display: flex; justify-content: space-between; align-items: center; padding: 14px 20px; background: var(--bg-elevated); border-bottom: 1px solid var(--border); }
-        .modal-header h2 { font-size: 14px; font-weight: 600; color: var(--text-primary); }
-        .modal-close { background: none; border: none; color: var(--text-dim); font-size: 20px; cursor: pointer; padding: 0 4px; }
-        .modal-close:hover { color: var(--red); }
-        .modal-body { padding: 20px; }
-        .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 24px; margin-bottom: 16px; }
-        .detail-item label { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 1px; }
-        .detail-item .val { font-size: 13px; color: var(--text-primary); margin-top: 2px; }
-
-        .tool-call-item {
-            background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 4px;
-            padding: 8px 12px; margin-bottom: 4px; border-left: 2px solid var(--cyan); font-size: 12px;
-        }
-        .tool-call-item.failed { border-left-color: var(--red); }
-        .tool-call-item .tc-header { display: flex; justify-content: space-between; color: var(--text-primary); font-weight: 500; }
-        .tool-call-item .tc-cmd { color: var(--text-dim); margin-top: 3px; font-size: 11px; word-break: break-all; }
-        .tool-call-item .tc-err { color: var(--red); margin-top: 3px; font-size: 11px; }
-
-        .files-list { list-style: none; padding: 0; }
-        .files-list li { padding: 3px 0; font-size: 12px; color: var(--cyan); }
-        .files-list li::before { content: '\2192 '; color: var(--text-dim); }
-
-        /* Command palette */
-        .cmd-overlay {
-            display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0;
-            background: rgba(0,0,0,0.7); z-index: 2000; padding: 20vh 0 0;
-        }
-        .cmd-dialog {
-            max-width: 560px; margin: 0 auto; background: var(--bg-surface); border: 1px solid var(--border);
-            border-radius: 10px; overflow: hidden; box-shadow: 0 16px 40px rgba(0,0,0,0.5);
-        }
-        .cmd-input {
-            width: 100%; background: transparent; border: none; border-bottom: 1px solid var(--border);
-            color: var(--text-primary); padding: 16px 20px; font-family: inherit; font-size: 14px;
-        }
-        .cmd-input:focus { outline: none; }
-        .cmd-input::placeholder { color: var(--text-dim); }
-        .cmd-results { max-height: 300px; overflow-y: auto; }
-        .cmd-item {
-            padding: 10px 20px; cursor: pointer; display: flex; align-items: center; gap: 10px;
-            font-size: 13px; color: var(--text-secondary); transition: background 0.1s;
-        }
-        .cmd-item:hover, .cmd-item.selected { background: var(--accent-glow); color: var(--accent); }
-        .cmd-item .cmd-icon { width: 20px; text-align: center; font-size: 14px; }
-        .cmd-hint { margin-left: auto; font-size: 10px; color: var(--text-dim); }
-
-        /* Inline edit form */
-        .edit-form { background: var(--bg-deep); border: 1px solid var(--border); border-radius: 6px; padding: 12px; margin-top: 8px; }
-        .edit-form textarea {
-            width: 100%; background: var(--bg-surface); border: 1px solid var(--border); color: var(--text-primary);
-            padding: 8px; border-radius: 4px; font-family: inherit; font-size: 12px; resize: vertical; min-height: 60px;
-        }
-        .edit-form textarea:focus { outline: none; border-color: var(--accent); }
-        .edit-form .edit-row { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
-        .edit-form input[type=range] { flex: 1; accent-color: var(--accent); }
-
-        .empty-state { text-align: center; padding: 60px 20px; color: var(--text-dim); }
-        .empty-state .empty-icon { font-size: 32px; margin-bottom: 12px; }
-        .empty-state .empty-text { font-size: 13px; }
-        .empty-state code { background: var(--bg-elevated); padding: 2px 6px; border-radius: 3px; color: var(--accent); }
-
-        .loading-state { text-align: center; padding: 40px; color: var(--accent); font-size: 12px; }
-        .loading-state::after { content: '...'; animation: dots 1.5s steps(4, end) infinite; }
-        @keyframes dots { 0%,20% { content: ''; } 40% { content: '.'; } 60% { content: '..'; } 80%,100% { content: '...'; } }
-
-        .tab-content { display: none; }
-        .tab-content.active { display: block; }
-
-        .statusbar {
-            display: flex; align-items: center; gap: 16px;
-            padding: 6px 24px; background: var(--bg-main); border-top: 1px solid var(--border);
-            font-size: 10px; color: var(--text-dim);
-        }
-        .statusbar .sep { width: 1px; height: 10px; background: var(--border); }
-
-        .section-label { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 1.5px; padding: 12px 14px 6px; }
-
-        .kbd { background: var(--bg-elevated); border: 1px solid var(--border); border-radius: 3px; padding: 1px 5px; font-size: 10px; color: var(--text-dim); }
-    </style>
+    <script
+        src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
+        integrity="sha384-8dbf0940c6cca015338166ad7dee823800a2da58dc0dd650d8ec5ccc60376c635e59efba0c284c4c125e99e77b667bc9"
+        crossorigin="anonymous"
+    ></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/dayjs@1.11.23/dayjs.min.js"
+        integrity="sha384-d45b78fc94cd6eded2ff8e15d218a6a5c8f1f987d0d5ae96e9260124cafde1b6ba8f06615a85a82da66c326b4920b82a"
+        crossorigin="anonymous"
+    ></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/dayjs@1.11.23/plugin/relativeTime.js"
+        integrity="sha384-b2c5333d05e32c72cedfd6bd022bb0c679f20f122f38c531110a6a7eb794696ee32c4743017885e94a286513b9dc5e99"
+        crossorigin="anonymous"
+    ></script>
+    <link rel="stylesheet" href="/assets/dashboard.css" />
 </head>
 <body>
     <div class="app">
@@ -355,7 +29,10 @@
                 <div class="logo-sub">agent memory system <span class="blink">_</span></div>
             </div>
             <div class="nav">
-                <div class="nav-item active" data-tab="sessions" onclick="switchTab('sessions')">
+                <div class="nav-item active" data-tab="home" onclick="switchTab('home')">
+                    <span class="nav-icon">&#x2302;</span> Home
+                </div>
+                <div class="nav-item" data-tab="sessions" onclick="switchTab('sessions')">
                     <span class="nav-icon">&#x229E;</span> Sessions
                     <span class="nav-badge" id="navSessions">-</span>
                 </div>
@@ -399,7 +76,7 @@
                     <button class="mode-btn" data-mode="xpath" onclick="setSearchMode('xpath')">XPath</button>
                 </div>
                 <div class="filter-chips">
-                    <span class="chip chip-claude active" onclick="toggleAgent(this,'claude')">Claude</span>
+                    <span class="chip chip-claude active" onclick="toggleAgent(this,'claude_code')">Claude</span>
                     <span class="chip chip-codex active" onclick="toggleAgent(this,'codex')">Codex</span>
                     <span class="chip chip-gemini active" onclick="toggleAgent(this,'gemini')">Gemini</span>
                 </div>
@@ -410,17 +87,48 @@
             </div>
 
             <div class="content">
-                <div class="stats-grid">
-                    <div class="stat-card"><div class="stat-label">sessions</div><div class="stat-value" id="statSessions">-</div></div>
-                    <div class="stat-card"><div class="stat-label">memories</div><div class="stat-value" id="statMemories">-</div></div>
-                    <div class="stat-card"><div class="stat-label">facts</div><div class="stat-value" id="statFacts">-</div></div>
-                    <div class="stat-card"><div class="stat-label">decisions</div><div class="stat-value" id="statDecisions">-</div></div>
-                    <div class="stat-card"><div class="stat-label">tool calls</div><div class="stat-value" id="statToolCalls">-</div></div>
-                    <div class="stat-card"><div class="stat-label">projects</div><div class="stat-value" id="statProjects">-</div></div>
+                <!-- Home -->
+                <div class="tab-content active" id="homePanel">
+                    <!-- Briefing Hero -->
+                    <div class="briefing-hero" id="briefingHero">
+                        <div class="briefing-headline" id="briefingHeadline"></div>
+                        <div class="briefing-metrics" id="briefingMetrics"></div>
+                        <div class="digest-grid" id="briefingDigest" style="display:none"></div>
+                    </div>
+
+                    <!-- Attention Bar -->
+                    <div class="attention-bar" id="attentionBar" style="display:none"></div>
+
+                    <div class="stats-grid">
+                        <div class="stat-card"><div class="stat-label">sessions</div><div class="stat-row"><div class="stat-value" id="statSessions">-</div><span class="sparkline" id="sparkSessions"></span></div><div class="trend" id="trendSessions"></div></div>
+                        <div class="stat-card"><div class="stat-label">memories</div><div class="stat-row"><div class="stat-value" id="statMemories">-</div><span class="sparkline" id="sparkMemories"></span></div><div class="trend" id="trendMemories"></div></div>
+                        <div class="stat-card"><div class="stat-label">facts</div><div class="stat-row"><div class="stat-value" id="statFacts">-</div></div></div>
+                        <div class="stat-card"><div class="stat-label">decisions</div><div class="stat-row"><div class="stat-value" id="statDecisions">-</div><span class="sparkline" id="sparkDecisions"></span></div><div class="trend" id="trendDecisions"></div></div>
+                        <div class="stat-card"><div class="stat-label">tool calls</div><div class="stat-row"><div class="stat-value" id="statToolCalls">-</div></div></div>
+                        <div class="stat-card"><div class="stat-label">projects</div><div class="stat-row"><div class="stat-value" id="statProjects">-</div></div></div>
+                    </div>
+
+                    <!-- Recent Activity -->
+                    <div class="panel" style="margin-bottom:16px">
+                        <div class="panel-header">
+                            <div class="panel-title">recent activity</div>
+                            <button class="btn btn-sm btn-ghost" onclick="switchTab('sessions')">View all sessions &rarr;</button>
+                        </div>
+                        <div id="homeActivityContent"><div class="loading-state">loading</div></div>
+                    </div>
+
+                    <!-- Recent Decisions -->
+                    <div class="panel">
+                        <div class="panel-header">
+                            <div class="panel-title">recent decisions</div>
+                            <button class="btn btn-sm btn-ghost" onclick="switchTab('decisions')">View all decisions &rarr;</button>
+                        </div>
+                        <div id="homeDecisionsContent" class="card-list"><div class="loading-state">loading</div></div>
+                    </div>
                 </div>
 
                 <!-- Sessions -->
-                <div class="tab-content active" id="sessionsPanel">
+                <div class="tab-content" id="sessionsPanel">
                     <div class="panel">
                         <div class="panel-header"><div class="panel-title">sessions <span class="count" id="sessionsCount"></span></div></div>
                         <div id="sessionsContent"><div class="loading-state">loading</div></div>
@@ -552,6 +260,7 @@
             </div>
             <div class="modal-body">
                 <textarea id="noteText" style="width:100%;background:var(--bg-elevated);border:1px solid var(--border);color:var(--text-primary);padding:10px;border-radius:6px;font-family:inherit;font-size:12px;min-height:80px;resize:vertical" placeholder="Write a note..."></textarea>
+                <input id="noteTags" type="text" placeholder="tags (comma-separated)" style="width:calc(100% - 22px);margin-top:8px;background:var(--bg-elevated);border:1px solid var(--border);color:var(--text-primary);padding:10px;border-radius:6px;font-family:inherit;font-size:12px" />
                 <div style="margin-top:10px;display:flex;gap:8px;justify-content:flex-end">
                     <button class="btn btn-ghost btn-sm" onclick="closeModal('noteModal')">cancel</button>
                     <button class="btn btn-sm" onclick="submitNote()">save note</button>
@@ -589,6 +298,7 @@
         <div class="cmd-dialog">
             <input class="cmd-input" id="cmdInput" placeholder="Type a command or search..." />
             <div class="cmd-results" id="cmdResults">
+                <div class="cmd-item" onclick="cmdGo('home')"><span class="cmd-icon">&#x2302;</span> Home <span class="cmd-hint">overview &amp; briefing</span></div>
                 <div class="cmd-item" onclick="cmdGo('sessions')"><span class="cmd-icon">&#x229E;</span> Sessions <span class="cmd-hint">view all sessions</span></div>
                 <div class="cmd-item" onclick="cmdGo('memories')"><span class="cmd-icon">&#x25C8;</span> Memories <span class="cmd-hint">browse memories</span></div>
                 <div class="cmd-item" onclick="cmdGo('facts')"><span class="cmd-icon">&#x25C6;</span> Facts <span class="cmd-hint">knowledge base</span></div>
@@ -598,596 +308,6 @@
         </div>
     </div>
 
-    <script>
-        // -----------------------------------------------------------------------
-        // State
-        // -----------------------------------------------------------------------
-        let allSessions = [];
-        let currentProject = '';
-        let sortField = 'started_at';
-        let sortAsc = false;
-        let searchMode = 'text';
-        let activeAgents = new Set(['claude', 'codex', 'gemini']);
-        let factsActiveOnly = true;
-        let charts = {};
-        let refreshTimer = null;
-
-        // -----------------------------------------------------------------------
-        // API helpers
-        // -----------------------------------------------------------------------
-        async function api(path, opts) {
-            const res = await fetch('/api/' + path, opts);
-            if (!res.ok) throw new Error('API ' + res.status);
-            return res.json();
-        }
-        async function apiPut(path, body) { return api(path, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }); }
-        async function apiPost(path, body) { return api(path, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }); }
-        async function apiDel(path) { return api(path, { method: 'DELETE' }); }
-        function esc(s) { return s ? s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;') : ''; }
-        function fmtDate(s) { try { return new Date(s).toLocaleDateString('en-US',{month:'short',day:'numeric'}); } catch { return s||''; } }
-        function fmtDateTime(s) { try { return new Date(s).toLocaleString(); } catch { return s||''; } }
-        function fmtNum(n) { if(n>=1e6) return (n/1e6).toFixed(1)+'M'; if(n>=1000) return (n/1000).toFixed(1)+'k'; return String(n); }
-        function confClass(c) { return c >= 0.8 ? 'conf-high' : c >= 0.5 ? 'conf-mid' : 'conf-low'; }
-        function confBar(c) {
-            const pct = Math.round(c * 100);
-            return '<span class="conf-bar"><span class="conf-track"><span class="conf-fill ' + confClass(c) + '" style="width:' + pct + '%"></span></span><span class="dim" style="font-size:10px">' + pct + '%</span></span>';
-        }
-        function agentTag(a) { return '<span class="agent-tag agent-' + (a||'').toLowerCase() + '">' + esc(a||'unknown') + '</span>'; }
-
-        // -----------------------------------------------------------------------
-        // Tab navigation
-        // -----------------------------------------------------------------------
-        function switchTab(tab) {
-            document.querySelectorAll('.nav-item').forEach(n => n.classList.remove('active'));
-            document.querySelectorAll('.tab-content').forEach(p => p.classList.remove('active'));
-            const navEl = document.querySelector('.nav-item[data-tab="' + tab + '"]');
-            if (navEl) navEl.classList.add('active');
-            document.getElementById(tab + 'Panel').classList.add('active');
-            if (tab === 'memories') loadMemories();
-            if (tab === 'decisions') loadDecisions();
-            if (tab === 'facts') loadFacts();
-            if (tab === 'analytics') loadAnalytics();
-        }
-
-        // -----------------------------------------------------------------------
-        // Stats
-        // -----------------------------------------------------------------------
-        async function loadStats() {
-            try {
-                const d = await api('stats');
-                document.getElementById('statSessions').textContent = fmtNum(d.sessions || 0);
-                document.getElementById('statMemories').textContent = fmtNum(d.memories || 0);
-                document.getElementById('statDecisions').textContent = fmtNum(d.decisions || 0);
-                document.getElementById('statToolCalls').textContent = fmtNum(d.tool_calls || 0);
-                document.getElementById('statProjects').textContent = d.projects || 0;
-                document.getElementById('navSessions').textContent = fmtNum(d.sessions || 0);
-                document.getElementById('navMemories').textContent = fmtNum(d.memories || 0);
-                document.getElementById('navDecisions').textContent = fmtNum(d.decisions || 0);
-                document.getElementById('sbProjects').textContent = (d.projects || 0) + ' projects';
-                // Load facts count
-                try {
-                    const facts = await api('facts?active_only=true&limit=1');
-                    const factCount = Array.isArray(facts) ? facts.length : 0;
-                    // Better: get from stats if available
-                    api('facts?active_only=true&limit=10000').then(f => {
-                        const c = Array.isArray(f) ? f.length : 0;
-                        document.getElementById('statFacts').textContent = fmtNum(c);
-                        document.getElementById('navFacts').textContent = fmtNum(c);
-                    }).catch(() => {});
-                } catch { document.getElementById('statFacts').textContent = '-'; }
-                document.getElementById('sbRefresh').textContent = 'updated ' + new Date().toLocaleTimeString();
-            } catch (e) {
-                document.getElementById('statSessions').textContent = 'ERR';
-            }
-        }
-
-        async function loadProjects() {
-            try {
-                const projects = await api('projects');
-                const sel = document.getElementById('projectFilter');
-                projects.forEach(p => { const o = document.createElement('option'); o.value = p; o.textContent = p; sel.appendChild(o); });
-                document.getElementById('sbAgents').textContent = projects.length + ' projects tracked';
-            } catch (e) { console.error('Projects:', e); }
-        }
-
-        // -----------------------------------------------------------------------
-        // Sessions
-        // -----------------------------------------------------------------------
-        async function loadSessions(project) {
-            try {
-                let url = 'sessions?limit=200';
-                if (project) url += '&project=' + encodeURIComponent(project);
-                const sessions = await api(url);
-                allSessions = sessions;
-                document.getElementById('sessionsCount').textContent = '(' + sessions.length + ')';
-                renderSessions(sessions);
-            } catch (e) {
-                document.getElementById('sessionsContent').innerHTML = '<div class="empty-state"><div class="empty-icon">&#x2297;</div><div class="empty-text">Error: ' + esc(String(e)) + '</div></div>';
-            }
-        }
-
-        function renderSessions(sessions) {
-            const filtered = sessions.filter(s => activeAgents.has((s.agent||'').toLowerCase()));
-            const el = document.getElementById('sessionsContent');
-            if (!filtered.length) {
-                el.innerHTML = '<div class="empty-state"><div class="empty-icon">&#x229E;</div><div class="empty-text">no sessions found. run <code>rem init</code> to begin.</div></div>';
-                return;
-            }
-            el.innerHTML = '<table><thead><tr>' +
-                '<th onclick="sortBy(\'agent\')">agent</th>' +
-                '<th onclick="sortBy(\'project_id\')">project</th>' +
-                '<th onclick="sortBy(\'started_at\')">date</th>' +
-                '<th>msgs</th><th>tools</th><th>tokens</th>' +
-                '<th onclick="sortBy(\'summary\')">summary</th>' +
-                '</tr></thead><tbody>' +
-                filtered.map(s => {
-                    const dt = s.started_at ? fmtDate(s.started_at) : '-';
-                    const sum = s.summary || '\u2014';
-                    return '<tr onclick="showDetail(\'' + esc(s.id) + '\')">' +
-                        '<td>' + agentTag(s.agent) + '</td>' +
-                        '<td class="dim" style="max-width:120px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + esc(s.project_id || '-') + '</td>' +
-                        '<td class="mono dim">' + dt + '</td>' +
-                        '<td class="mono">' + (s.message_count || '-') + '</td>' +
-                        '<td class="mono">' + (s.tool_call_count || '-') + '</td>' +
-                        '<td class="mono dim">' + (s.total_tokens ? fmtNum(s.total_tokens) : '-') + '</td>' +
-                        '<td class="truncate" title="' + esc(sum) + '">' + esc(sum) + '</td></tr>';
-                }).join('') + '</tbody></table>';
-        }
-
-        function sortBy(field) {
-            if (sortField === field) sortAsc = !sortAsc;
-            else { sortField = field; sortAsc = true; }
-            allSessions.sort((a, b) => { const av = a[field]||'', bv = b[field]||''; return sortAsc ? (av > bv ? 1 : -1) : (av < bv ? 1 : -1); });
-            renderSessions(allSessions);
-        }
-
-        async function showDetail(id) {
-            try {
-                const data = await api('sessions/' + encodeURIComponent(id));
-                const s = data.session;
-                const tcs = data.tool_calls || [];
-                let html = '<div class="detail-grid">' +
-                    '<div class="detail-item"><label>id</label><div class="val dim" style="font-size:11px;word-break:break-all">' + esc(s.id) + '</div></div>' +
-                    '<div class="detail-item"><label>agent</label><div class="val">' + agentTag(s.agent) + '</div></div>' +
-                    '<div class="detail-item"><label>project</label><div class="val">' + esc(s.project_id || '-') + '</div></div>' +
-                    '<div class="detail-item"><label>duration</label><div class="val">' + (s.duration_minutes || '-') + ' min</div></div>' +
-                    '<div class="detail-item"><label>started</label><div class="val mono">' + fmtDateTime(s.started_at) + '</div></div>' +
-                    '<div class="detail-item"><label>ended</label><div class="val mono">' + fmtDateTime(s.ended_at) + '</div></div>' +
-                    '<div class="detail-item"><label>messages</label><div class="val mono">' + (s.message_count || '-') + '</div></div>' +
-                    '<div class="detail-item"><label>tokens</label><div class="val mono">' + (s.total_tokens ? fmtNum(s.total_tokens) : '-') + '</div></div></div>';
-                if (s.summary) html += '<div style="margin-bottom:14px"><label style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:1px">summary</label><div style="margin-top:4px;color:var(--text-secondary);font-size:12px;line-height:1.6">' + esc(s.summary) + '</div></div>';
-                if (s.files_changed && s.files_changed.length) html += '<div style="margin-bottom:14px"><label style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:1px">files changed (' + s.files_changed.length + ')</label><ul class="files-list">' + s.files_changed.map(f => '<li>' + esc(f) + '</li>').join('') + '</ul></div>';
-                if (tcs.length) {
-                    html += '<div><label style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:1px">tool calls (' + tcs.length + ')</label>';
-                    tcs.slice(0, 50).forEach(tc => {
-                        const cls = tc.success === false ? ' failed' : '';
-                        const ts = tc.timestamp ? new Date(tc.timestamp).toLocaleTimeString() : '';
-                        html += '<div class="tool-call-item' + cls + '"><div class="tc-header"><span>' + esc(tc.tool_name || 'unknown') + '</span><span class="dim">' + ts + '</span></div>' +
-                            (tc.command ? '<div class="tc-cmd">' + esc(tc.command.substring(0, 150)) + (tc.command.length > 150 ? '\u2026' : '') + '</div>' : '') +
-                            (tc.error_message ? '<div class="tc-err">' + esc(tc.error_message) + '</div>' : '') + '</div>';
-                    });
-                    if (tcs.length > 50) html += '<div class="dim" style="padding:8px;font-size:11px">...and ' + (tcs.length - 50) + ' more</div>';
-                    html += '</div>';
-                }
-                document.getElementById('modalTitle').textContent = 'Session \u2014 ' + (s.agent || '');
-                document.getElementById('detailContent').innerHTML = html;
-                document.getElementById('detailModal').style.display = 'block';
-            } catch (e) { console.error('Detail:', e); }
-        }
-
-        // -----------------------------------------------------------------------
-        // Memories
-        // -----------------------------------------------------------------------
-        async function loadMemories() {
-            const el = document.getElementById('memoriesContent');
-            try {
-                let url = 'memories?limit=200';
-                if (currentProject) url += '&project=' + encodeURIComponent(currentProject);
-                const memories = await api(url);
-                if (!memories.length) { el.innerHTML = '<div class="empty-state"><div class="empty-icon">&#x25C8;</div><div class="empty-text">no memories extracted yet</div></div>'; return; }
-                el.innerHTML = memories.map(m => {
-                    const t = m.memory_type || 'general';
-                    const d = m.created_at ? fmtDate(m.created_at) : '';
-                    const conf = typeof m.confidence === 'number' ? m.confidence : 1.0;
-                    return '<div class="memory-card" id="mem-' + esc(m.id) + '">' +
-                        '<div class="card-meta"><span class="card-type">' + esc(t) + '</span>' +
-                        '<div style="display:flex;align-items:center;gap:8px">' + confBar(conf) +
-                        '<span class="card-date">' + d + '</span>' +
-                        '<div class="card-actions"><button onclick="editMemory(\'' + esc(m.id) + '\',event)" title="edit">&#x270E;</button><button class="del" onclick="deleteMemory(\'' + esc(m.id) + '\',event)" title="delete">&#x2715;</button></div>' +
-                        '</div></div>' +
-                        '<div class="card-body">' + esc(m.content) + '</div>' +
-                        (m.project_id ? '<div class="card-footer">project: ' + esc(m.project_id) + '</div>' : '') +
-                        '</div>';
-                }).join('');
-            } catch (e) { el.innerHTML = '<div class="empty-state"><div class="empty-icon">&#x2297;</div><div class="empty-text">failed to load</div></div>'; }
-        }
-
-        async function editMemory(id, ev) {
-            ev.stopPropagation();
-            const card = document.getElementById('mem-' + id);
-            if (card.querySelector('.edit-form')) return;
-            const body = card.querySelector('.card-body');
-            const current = body.textContent;
-            const form = document.createElement('div');
-            form.className = 'edit-form';
-            form.innerHTML = '<textarea>' + esc(current) + '</textarea>' +
-                '<div class="edit-row"><span style="font-size:10px;color:var(--text-dim)">confidence:</span><input type="range" min="0" max="100" value="80" id="confSlider-' + id + '"><span id="confVal-' + id + '" style="font-size:10px;color:var(--text-dim);width:30px">80%</span></div>' +
-                '<div style="display:flex;gap:6px;justify-content:flex-end;margin-top:8px"><button class="btn btn-sm btn-ghost" onclick="this.closest(\'.edit-form\').remove()">cancel</button><button class="btn btn-sm" onclick="saveMemory(\'' + esc(id) + '\',this)">save</button></div>';
-            card.appendChild(form);
-            const slider = form.querySelector('input[type=range]');
-            const valEl = form.querySelector('[id^=confVal]');
-            slider.oninput = () => { valEl.textContent = slider.value + '%'; };
-        }
-
-        async function saveMemory(id, btn) {
-            const form = btn.closest('.edit-form');
-            const content = form.querySelector('textarea').value;
-            const conf = parseInt(form.querySelector('input[type=range]').value) / 100;
-            try {
-                await apiPut('memories/' + encodeURIComponent(id), { content, confidence: conf });
-                loadMemories();
-            } catch (e) { alert('Failed: ' + e.message); }
-        }
-
-        async function deleteMemory(id, ev) {
-            ev.stopPropagation();
-            if (!confirm('Delete this memory?')) return;
-            try { await apiDel('memories/' + encodeURIComponent(id)); loadMemories(); }
-            catch (e) { alert('Failed: ' + e.message); }
-        }
-
-        // -----------------------------------------------------------------------
-        // Facts
-        // -----------------------------------------------------------------------
-        async function loadFacts() {
-            const el = document.getElementById('factsContent');
-            el.innerHTML = '<div class="loading-state">loading</div>';
-            try {
-                const url = 'facts?limit=200&active_only=' + factsActiveOnly;
-                if (currentProject) url += '&project=' + encodeURIComponent(currentProject);
-                const facts = await api(url);
-                document.getElementById('factsCount').textContent = '(' + facts.length + ')';
-                if (!facts.length) { el.innerHTML = '<div class="empty-state"><div class="empty-icon">&#x25C6;</div><div class="empty-text">no facts in knowledge base</div></div>'; return; }
-                el.innerHTML = '<table><thead><tr><th>subject</th><th>predicate</th><th>object</th><th>confidence</th><th>agent</th><th>status</th></tr></thead><tbody>' +
-                    facts.map(f => {
-                        const active = !f.invalid_at;
-                        const cls = active ? 'fact-active' : 'fact-inactive';
-                        return '<tr class="' + cls + '" onclick="showFactHistory(\'' + esc(f.id) + '\')" style="cursor:pointer">' +
-                            '<td' + (active ? '' : ' class="fact-superseded"') + '>' + esc(f.subject) + '</td>' +
-                            '<td class="dim">' + esc(f.predicate) + '</td>' +
-                            '<td' + (active ? '' : ' class="fact-superseded"') + '>' + esc(f.object) + '</td>' +
-                            '<td>' + confBar(f.confidence || 1.0) + '</td>' +
-                            '<td class="dim">' + esc(f.source_agent || '-') + '</td>' +
-                            '<td><span class="status-badge">' + (active ? 'active' : 'superseded') + '</span></td></tr>';
-                    }).join('') + '</tbody></table>';
-            } catch (e) { el.innerHTML = '<div class="empty-state"><div class="empty-icon">&#x2297;</div><div class="empty-text">failed to load facts</div></div>'; }
-        }
-
-        function toggleFactsFilter() {
-            factsActiveOnly = !factsActiveOnly;
-            document.getElementById('factsToggle').textContent = factsActiveOnly ? 'active only' : 'show all';
-            loadFacts();
-        }
-
-        async function showFactHistory(id) {
-            try {
-                const history = await api('facts/' + encodeURIComponent(id) + '/history');
-                if (!Array.isArray(history) || !history.length) { alert('No history found'); return; }
-                const subject = history[0].subject;
-                let html = '<h3 style="font-size:13px;margin-bottom:12px;color:var(--text-secondary)">Evolution of: <span style="color:var(--accent)">' + esc(subject) + '</span></h3>';
-                html += '<div class="timeline">';
-                history.forEach((f, i) => {
-                    const active = !f.invalid_at;
-                    const prev = i > 0 ? history[i-1] : null;
-                    html += '<div class="timeline-item' + (active ? '' : ' superseded') + '">' +
-                        '<div class="timeline-meta">' + fmtDateTime(f.valid_at || f.created_at) + '<br>' +
-                        '<span style="color:' + (active ? 'var(--accent)' : 'var(--text-dim)') + '">' + (active ? 'ACTIVE' : 'superseded') + '</span>' +
-                        (f.source_agent ? '<br>' + esc(f.source_agent) : '') + '</div>' +
-                        '<div class="timeline-content">' +
-                        (prev && prev.object !== f.object ? '<div class="timeline-diff-del">' + esc(prev.predicate) + ' ' + esc(prev.object) + '</div>' : '') +
-                        '<div' + (prev && prev.object !== f.object ? ' class="timeline-diff-add"' : '') + '>' + esc(f.predicate) + ' <strong>' + esc(f.object) + '</strong></div>' +
-                        '<div style="margin-top:4px">' + confBar(f.confidence || 1.0) + '</div>' +
-                        '</div></div>';
-                });
-                html += '</div>';
-                document.getElementById('factModalTitle').textContent = 'Fact History \u2014 ' + subject;
-                document.getElementById('factModalContent').innerHTML = html;
-                document.getElementById('factModal').style.display = 'block';
-            } catch (e) { console.error('Fact history:', e); }
-        }
-
-        // -----------------------------------------------------------------------
-        // Decisions
-        // -----------------------------------------------------------------------
-        async function loadDecisions() {
-            const el = document.getElementById('decisionsContent');
-            try {
-                let url = 'decisions';
-                if (currentProject) url += '?project=' + encodeURIComponent(currentProject);
-                const decisions = await api(url);
-                if (!decisions.length) { el.innerHTML = '<div class="empty-state"><div class="empty-icon">&#x2298;</div><div class="empty-text">no decisions recorded yet</div></div>'; return; }
-                el.innerHTML = decisions.map(d => {
-                    const dt = d.created_at ? fmtDate(d.created_at) : '';
-                    return '<div class="decision-card">' +
-                        '<div class="card-meta"><span class="card-type">' + esc(d.decision_type || 'decision') + '</span><span class="card-date">' + dt + '</span></div>' +
-                        '<div class="card-body" style="color:var(--text-primary);font-weight:500">' + esc(d.what) + '</div>' +
-                        (d.why ? '<div class="card-body" style="margin-top:4px">\u21B3 ' + esc(d.why) + '</div>' : '') +
-                        (d.alternatives && d.alternatives.length ? '<div class="card-footer">alternatives: ' + d.alternatives.map(esc).join(' \u00B7 ') + '</div>' : '') +
-                        (d.project_id ? '<div class="card-footer">project: ' + esc(d.project_id) + '</div>' : '') + '</div>';
-                }).join('');
-            } catch (e) { el.innerHTML = '<div class="empty-state"><div class="empty-icon">&#x2297;</div><div class="empty-text">failed to load</div></div>'; }
-        }
-
-        // -----------------------------------------------------------------------
-        // Analytics
-        // -----------------------------------------------------------------------
-        const AGENT_COLORS = { claude: '#58a6ff', codex: '#00ff9c', gemini: '#bc8cff' };
-        const chartDefaults = { responsive: true, maintainAspectRatio: false, plugins: { legend: { labels: { color: '#8b949e', font: { family: 'JetBrains Mono', size: 10 } } } }, scales: { x: { ticks: { color: '#484f58', font: { family: 'JetBrains Mono', size: 9 } }, grid: { color: '#21262d' } }, y: { ticks: { color: '#484f58', font: { family: 'JetBrains Mono', size: 9 } }, grid: { color: '#21262d' } } } };
-
-        async function loadAnalytics() {
-            await Promise.all([loadAgentStats(), loadTimeline(), loadToolStats(), loadHotfiles()]);
-        }
-
-        async function loadAgentStats() {
-            try {
-                const agents = await api('stats/agents');
-                if (!Array.isArray(agents)) return;
-                // Metric cards
-                const el = document.getElementById('agentMetrics');
-                el.innerHTML = agents.map(a => {
-                    const color = AGENT_COLORS[a.agent?.toLowerCase()] || 'var(--text-primary)';
-                    return '<div class="metric-card"><div class="metric-agent" style="color:' + color + '">' + esc(a.agent) + '</div>' +
-                        '<div class="metric-val">' + fmtNum(a.sessions || 0) + '</div><div class="metric-label">sessions</div>' +
-                        '<div style="margin-top:8px;font-size:12px;color:var(--text-secondary)">' + fmtNum(a.total_tokens || 0) + ' tokens</div>' +
-                        '<div class="metric-label">' + (a.avg_duration ? Math.round(a.avg_duration) + ' min avg' : '-') + '</div></div>';
-                }).join('');
-                // Doughnut chart
-                if (charts.agent) charts.agent.destroy();
-                charts.agent = new Chart(document.getElementById('agentChart'), {
-                    type: 'doughnut',
-                    data: { labels: agents.map(a => a.agent), datasets: [{ data: agents.map(a => a.sessions || 0), backgroundColor: agents.map(a => AGENT_COLORS[a.agent?.toLowerCase()] || '#8b949e'), borderWidth: 0 }] },
-                    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { position: 'right', labels: { color: '#8b949e', font: { family: 'JetBrains Mono', size: 10 }, padding: 12 } } } }
-                });
-                // Token bar chart
-                if (charts.token) charts.token.destroy();
-                charts.token = new Chart(document.getElementById('tokenChart'), {
-                    type: 'bar',
-                    data: { labels: agents.map(a => a.agent), datasets: [{ label: 'Tokens', data: agents.map(a => a.total_tokens || 0), backgroundColor: agents.map(a => AGENT_COLORS[a.agent?.toLowerCase()] || '#8b949e'), borderRadius: 4 }] },
-                    options: { ...chartDefaults, indexAxis: 'y', plugins: { ...chartDefaults.plugins, legend: { display: false } } }
-                });
-            } catch (e) { console.error('Agent stats:', e); }
-        }
-
-        async function loadTimeline() {
-            try {
-                const data = await api('stats/timeline?days=30');
-                if (!Array.isArray(data) || !data.length) return;
-                const dates = [...new Set(data.map(d => d.date))].sort();
-                const agentNames = [...new Set(data.map(d => d.agent))];
-                const datasets = agentNames.map(agent => ({
-                    label: agent,
-                    data: dates.map(date => { const m = data.find(d => d.date === date && d.agent === agent); return m ? m.count : 0; }),
-                    borderColor: AGENT_COLORS[agent?.toLowerCase()] || '#8b949e',
-                    backgroundColor: (AGENT_COLORS[agent?.toLowerCase()] || '#8b949e') + '33',
-                    fill: true, tension: 0.3, borderWidth: 2, pointRadius: 1
-                }));
-                if (charts.timeline) charts.timeline.destroy();
-                charts.timeline = new Chart(document.getElementById('timelineChart'), {
-                    type: 'line',
-                    data: { labels: dates.map(d => { const dt = new Date(d); return dt.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }); }), datasets },
-                    options: { ...chartDefaults, plugins: { ...chartDefaults.plugins, legend: { labels: { color: '#8b949e', font: { family: 'JetBrains Mono', size: 10 } } } } }
-                });
-            } catch (e) { console.error('Timeline:', e); }
-        }
-
-        async function loadToolStats() {
-            try {
-                const tools = await api('stats/tools');
-                if (!Array.isArray(tools) || !tools.length) return;
-                const top10 = tools.slice(0, 10);
-                const colors = ['#00ff9c', '#58a6ff', '#bc8cff', '#ffa657', '#ff7b72', '#e3b341', '#79c0ff', '#7ee787', '#d2a8ff', '#ffa198'];
-                if (charts.tool) charts.tool.destroy();
-                charts.tool = new Chart(document.getElementById('toolChart'), {
-                    type: 'doughnut',
-                    data: { labels: top10.map(t => t.tool_name || 'unknown'), datasets: [{ data: top10.map(t => t.count || 0), backgroundColor: colors, borderWidth: 0 }] },
-                    options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { position: 'right', labels: { color: '#8b949e', font: { family: 'JetBrains Mono', size: 9 }, padding: 8 } } } }
-                });
-                // Table
-                const el = document.getElementById('toolStatsContent');
-                el.innerHTML = '<table><thead><tr><th>tool</th><th>calls</th><th>success rate</th><th>avg duration</th></tr></thead><tbody>' +
-                    tools.map(t => {
-                        const rate = t.count > 0 ? Math.round((t.success_count / t.count) * 100) : 0;
-                        const rateColor = rate >= 90 ? 'var(--accent)' : rate >= 70 ? 'var(--yellow)' : 'var(--red)';
-                        return '<tr><td>' + esc(t.tool_name || 'unknown') + '</td><td class="mono">' + fmtNum(t.count) + '</td>' +
-                            '<td class="mono" style="color:' + rateColor + '">' + rate + '%</td>' +
-                            '<td class="mono dim">' + (t.avg_duration_ms ? Math.round(t.avg_duration_ms) + 'ms' : '-') + '</td></tr>';
-                    }).join('') + '</tbody></table>';
-            } catch (e) { console.error('Tool stats:', e); }
-        }
-
-        async function loadHotfiles() {
-            try {
-                const files = await api('hotfiles?limit=15');
-                if (!Array.isArray(files) || !files.length) return;
-                if (charts.hotfile) charts.hotfile.destroy();
-                const labels = files.map(f => { const p = f.file_path || f[0] || ''; return p.length > 40 ? '...' + p.slice(-37) : p; });
-                const data = files.map(f => f.change_frequency || f[1] || 0);
-                charts.hotfile = new Chart(document.getElementById('hotfileChart'), {
-                    type: 'bar',
-                    data: { labels, datasets: [{ label: 'Changes', data, backgroundColor: '#00ff9c44', borderColor: '#00ff9c', borderWidth: 1, borderRadius: 3 }] },
-                    options: { ...chartDefaults, indexAxis: 'y', plugins: { ...chartDefaults.plugins, legend: { display: false } }, scales: { ...chartDefaults.scales, y: { ...chartDefaults.scales.y, ticks: { ...chartDefaults.scales.y.ticks, font: { family: 'JetBrains Mono', size: 8 } } } } }
-                });
-            } catch (e) { console.error('Hotfiles:', e); }
-        }
-
-        // -----------------------------------------------------------------------
-        // Search
-        // -----------------------------------------------------------------------
-        function setSearchMode(mode) {
-            searchMode = mode;
-            document.querySelectorAll('.mode-btn').forEach(b => b.classList.toggle('active', b.dataset.mode === mode));
-            const input = document.getElementById('searchInput');
-            if (mode === 'xpath') input.placeholder = '//Session[node~"auth"]/Decision';
-            else if (mode === 'facts') input.placeholder = 'search facts by subject or object...';
-            else input.placeholder = 'search sessions, memories, facts...';
-        }
-
-        function toggleAgent(el, agent) {
-            el.classList.toggle('active');
-            if (activeAgents.has(agent)) activeAgents.delete(agent); else activeAgents.add(agent);
-            renderSessions(allSessions);
-        }
-
-        async function performSearch() {
-            const q = document.getElementById('searchInput').value.trim();
-            if (!q) return;
-            const el = document.getElementById('searchContent');
-            el.innerHTML = '<div class="loading-state">searching</div>';
-            document.getElementById('navSearchItem').style.display = '';
-            switchTab('search');
-
-            try {
-                const eq = encodeURIComponent(q);
-                let html = '';
-                if (searchMode === 'xpath') {
-                    const results = await api('search/xpath?q=' + eq + '&limit=20');
-                    if (Array.isArray(results) && results.length) {
-                        html += '<div class="section-label">xpath results (' + results.length + ')</div>';
-                        results.forEach(r => {
-                            html += '<div class="memory-card"><div class="card-meta"><span class="card-type">' + esc(r.node_type || r.result_type || 'node') + '</span>' +
-                                '<span class="card-date">score: ' + (r.weight || r.score || 0).toFixed(2) + '</span></div>' +
-                                '<div class="card-body">' + esc(r.name || r.content || '') + '</div>' +
-                                (r.path ? '<div class="card-footer">path: ' + r.path.map(esc).join(' \u2192 ') + '</div>' : '') + '</div>';
-                        });
-                    } else html = '<div class="empty-state"><div class="empty-icon">&#x2295;</div><div class="empty-text">no XPath results for "' + esc(q) + '"</div></div>';
-                } else if (searchMode === 'facts') {
-                    const facts = await api('search/facts?q=' + eq);
-                    if (Array.isArray(facts) && facts.length) {
-                        html += '<div class="section-label">facts (' + facts.length + ')</div>';
-                        facts.forEach(f => {
-                            const active = !f.invalid_at;
-                            html += '<div class="memory-card" style="border-left-color:var(--orange)"><div class="card-meta"><span class="card-type" style="color:var(--orange)">fact</span>' +
-                                '<span class="status-badge">' + (active ? 'active' : 'superseded') + '</span></div>' +
-                                '<div class="card-body"><strong>' + esc(f.subject) + '</strong> ' + esc(f.predicate) + ' <strong>' + esc(f.object) + '</strong></div>' +
-                                '<div class="card-footer">' + confBar(f.confidence || 1.0) + '</div></div>';
-                        });
-                    } else html = '<div class="empty-state"><div class="empty-icon">&#x2295;</div><div class="empty-text">no facts matching "' + esc(q) + '"</div></div>';
-                } else {
-                    const [sessions, memories] = await Promise.all([api('search/sessions?q=' + eq), api('search/memories?q=' + eq)]);
-                    if (sessions.length) {
-                        html += '<div class="section-label">sessions (' + sessions.length + ')</div>';
-                        sessions.forEach(s => {
-                            const dt = s.started_at ? fmtDate(s.started_at) : '';
-                            html += '<div class="memory-card" style="cursor:pointer;border-left-color:var(--blue)" onclick="showDetail(\'' + esc(s.id) + '\')">' +
-                                '<div class="card-meta"><div style="display:flex;gap:6px;align-items:center">' + agentTag(s.agent) + '<span class="dim">' + esc(s.project_id || '') + '</span></div><span class="card-date">' + dt + '</span></div>' +
-                                '<div class="card-body">' + esc(s.summary || '\u2014') + '</div></div>';
-                        });
-                    }
-                    if (memories.length) {
-                        html += '<div class="section-label">memories (' + memories.length + ')</div>';
-                        memories.forEach(m => {
-                            html += '<div class="memory-card"><div class="card-meta"><span class="card-type">' + esc(m.memory_type || 'general') + '</span></div><div class="card-body">' + esc(m.content) + '</div></div>';
-                        });
-                    }
-                    if (!sessions.length && !memories.length) html = '<div class="empty-state"><div class="empty-icon">&#x2295;</div><div class="empty-text">no results for "' + esc(q) + '"</div></div>';
-                }
-                el.innerHTML = html;
-            } catch (e) { el.innerHTML = '<div class="empty-state"><div class="empty-icon">&#x2297;</div><div class="empty-text">search failed: ' + esc(e.message) + '</div></div>'; }
-        }
-
-        function clearSearch() {
-            document.getElementById('searchInput').value = '';
-            document.getElementById('navSearchItem').style.display = 'none';
-            switchTab('sessions');
-        }
-
-        // -----------------------------------------------------------------------
-        // Add Note / Decision
-        // -----------------------------------------------------------------------
-        function showAddNote() { document.getElementById('noteModal').style.display = 'block'; document.getElementById('noteText').focus(); }
-        function showAddDecision() { document.getElementById('decisionModal').style.display = 'block'; document.getElementById('decWhat').focus(); }
-
-        async function submitNote() {
-            const text = document.getElementById('noteText').value.trim();
-            if (!text) return;
-            try {
-                await apiPost('notes', { text, project: currentProject || undefined });
-                document.getElementById('noteText').value = '';
-                closeModal('noteModal');
-                loadMemories();
-            } catch (e) { alert('Failed: ' + e.message); }
-        }
-
-        async function submitDecision() {
-            const what = document.getElementById('decWhat').value.trim();
-            const why = document.getElementById('decWhy').value.trim();
-            if (!what) return;
-            try {
-                await apiPost('decisions', { what, why: why || undefined, project: currentProject || undefined });
-                document.getElementById('decWhat').value = '';
-                document.getElementById('decWhy').value = '';
-                closeModal('decisionModal');
-                loadDecisions();
-            } catch (e) { alert('Failed: ' + e.message); }
-        }
-
-        // -----------------------------------------------------------------------
-        // Modals & Command Palette
-        // -----------------------------------------------------------------------
-        function closeModal(id) { document.getElementById(id).style.display = 'none'; }
-
-        function openCmdPalette() {
-            document.getElementById('cmdPalette').style.display = 'block';
-            const input = document.getElementById('cmdInput');
-            input.value = '';
-            input.focus();
-        }
-        function closeCmdPalette() { document.getElementById('cmdPalette').style.display = 'none'; }
-
-        function cmdGo(tab) { closeCmdPalette(); switchTab(tab); }
-
-        // -----------------------------------------------------------------------
-        // Keyboard shortcuts
-        // -----------------------------------------------------------------------
-        document.addEventListener('keydown', e => {
-            // Cmd+K or Ctrl+K → command palette
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') { e.preventDefault(); openCmdPalette(); return; }
-            // Escape → close modals
-            if (e.key === 'Escape') {
-                if (document.getElementById('cmdPalette').style.display === 'block') { closeCmdPalette(); return; }
-                document.querySelectorAll('.modal-overlay').forEach(m => m.style.display = 'none');
-                return;
-            }
-            // Don't handle shortcuts when typing in inputs
-            if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
-            // / → focus search
-            if (e.key === '/') { e.preventDefault(); document.getElementById('searchInput').focus(); }
-        });
-
-        document.getElementById('searchInput').addEventListener('keydown', e => { if (e.key === 'Enter') performSearch(); });
-
-        document.getElementById('cmdInput').addEventListener('keydown', e => {
-            if (e.key === 'Escape') closeCmdPalette();
-            if (e.key === 'Enter') {
-                const val = e.target.value.trim().toLowerCase();
-                const tabs = ['sessions', 'memories', 'facts', 'decisions', 'analytics'];
-                const match = tabs.find(t => t.startsWith(val));
-                if (match) cmdGo(match);
-                else { closeCmdPalette(); document.getElementById('searchInput').value = e.target.value; performSearch(); }
-            }
-        });
-
-        document.getElementById('cmdPalette').addEventListener('click', e => { if (e.target === document.getElementById('cmdPalette')) closeCmdPalette(); });
-        document.querySelectorAll('.modal-overlay').forEach(m => m.addEventListener('click', e => { if (e.target === m) m.style.display = 'none'; }));
-
-        document.getElementById('projectFilter').addEventListener('change', e => { currentProject = e.target.value; loadSessions(currentProject); });
-
-        // -----------------------------------------------------------------------
-        // Init
-        // -----------------------------------------------------------------------
-        loadStats();
-        loadProjects();
-        loadSessions();
-    </script>
+    <script src="/assets/dashboard.js" defer></script>
 </body>
 </html>

--- a/cli/src/web_dashboard.js
+++ b/cli/src/web_dashboard.js
@@ -1,0 +1,1693 @@
+// -----------------------------------------------------------------------
+// State
+// -----------------------------------------------------------------------
+let allSessions = [];
+let currentProject = "";
+let sortField = "started_at";
+let sortAsc = false;
+let searchMode = "text";
+let activeAgents = new Set(["claude_code", "codex", "gemini"]);
+let factsActiveOnly = true;
+let charts = {};
+const AGENT_COLORS = {
+  claude: "#58a6ff",
+  claude_code: "#58a6ff",
+  codex: "#00ff9c",
+  gemini: "#bc8cff",
+};
+
+// -----------------------------------------------------------------------
+// API helpers
+// -----------------------------------------------------------------------
+async function api(path, opts) {
+  const res = await fetch("/api/" + path, opts);
+  if (!res.ok) throw new Error("API " + res.status);
+  return res.json();
+}
+async function apiPut(path, body) {
+  return api(path, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+async function apiPost(path, body) {
+  return api(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+async function apiDel(path) {
+  return api(path, { method: "DELETE" });
+}
+function esc(value) {
+  return value
+    ? String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+    : "";
+}
+function jsArg(value) {
+  return String(value ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'")
+    .replace(/"/g, "&quot;")
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n");
+}
+function parseUtcDate(value) {
+  const raw = String(value ?? "");
+  const iso = raw.includes(" ") ? raw.replace(" ", "T") : raw;
+  const hasZone = /(?:Z|[+-]\d\d:?\d\d)$/i.test(iso);
+  return new Date(hasZone ? iso : `${iso}Z`);
+}
+function formatIsoDay(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value ?? ""));
+  if (!match) return String(value ?? "");
+  const months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+  const month = months[Number(match[2]) - 1] ?? match[2];
+  return `${month} ${Number(match[3])}`;
+}
+function fmtDate(s) {
+  try {
+    return esc(
+      parseUtcDate(s).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      }),
+    );
+  } catch {
+    return esc(s || "");
+  }
+}
+function fmtDateTime(s) {
+  try {
+    return esc(parseUtcDate(s).toLocaleString());
+  } catch {
+    return esc(s || "");
+  }
+}
+function fmtNum(n) {
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
+  if (n >= 1000) return (n / 1000).toFixed(1) + "k";
+  return String(n);
+}
+function confClass(c) {
+  return c >= 0.8 ? "conf-high" : c >= 0.5 ? "conf-mid" : "conf-low";
+}
+function confBar(c) {
+  const pct = Math.round(c * 100);
+  return (
+    '<span class="conf-bar"><span class="conf-track"><span class="conf-fill ' +
+    confClass(c) +
+    '" style="width:' +
+    pct +
+    '%"></span></span><span class="dim" style="font-size:10px">' +
+    pct +
+    "%</span></span>"
+  );
+}
+function agentTag(a) {
+  return (
+    '<span class="agent-tag agent-' +
+    safeToken(a || "unknown") +
+    '">' +
+    esc(a || "unknown") +
+    "</span>"
+  );
+}
+function safeToken(value) {
+  return String(value || "unknown")
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]/g, "-");
+}
+function memoryTags(m) {
+  return Array.isArray(m.tags) && m.tags.length
+    ? '<div class="card-footer">tags: ' + m.tags.map(esc).join(", ") + "</div>"
+    : "";
+}
+
+// Day.js relative time
+if (window.dayjs && dayjs.extend) {
+  dayjs.extend(window.dayjs_plugin_relativeTime);
+}
+function relTime(s) {
+  try {
+    return dayjs(parseUtcDate(s)).fromNow();
+  } catch {
+    return fmtDate(s);
+  }
+}
+
+function renderSparkline(data, color) {
+  if (!data || !data.length) return "";
+  const w = 60,
+    h = 18,
+    pad = 1;
+  const vals = data.map((d) => (typeof d === "number" ? d : d.value || 0));
+  const max = Math.max(...vals, 1);
+  const min = Math.min(...vals, 0);
+  const range = max - min || 1;
+  const pts = vals
+    .map((v, i) => {
+      const x = pad + (i / (vals.length - 1 || 1)) * (w - 2 * pad);
+      const y = h - pad - ((v - min) / range) * (h - 2 * pad);
+      return x.toFixed(1) + "," + y.toFixed(1);
+    })
+    .join(" ");
+  return (
+    '<svg width="' +
+    w +
+    '" height="' +
+    h +
+    '" viewBox="0 0 ' +
+    w +
+    " " +
+    h +
+    '"><polyline points="' +
+    pts +
+    '" fill="none" stroke="' +
+    (color || "var(--accent)") +
+    '" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+  );
+}
+
+function trendIndicator(current, previous) {
+  if (previous === 0 && current === 0)
+    return '<span class="trend trend-flat">&rarr; steady</span>';
+  if (previous === 0) return '<span class="trend trend-up">&uarr; new</span>';
+  const pct = Math.round(((current - previous) / previous) * 100);
+  if (pct > 0) return '<span class="trend trend-up">&uarr; ' + pct + "%</span>";
+  if (pct < 0)
+    return (
+      '<span class="trend trend-down">&darr; ' + Math.abs(pct) + "%</span>"
+    );
+  return '<span class="trend trend-flat">&rarr; steady</span>';
+}
+
+async function loadBriefing() {
+  try {
+    const b = await api("briefing");
+    document.getElementById("briefingHeadline").innerHTML = esc(
+      b.headline || "",
+    ).replace(/(\d+)/g, "<strong>$1</strong>");
+    // Metrics row
+    const mEl = document.getElementById("briefingMetrics");
+    const metrics = b.metrics || {};
+    let mHtml = "";
+    for (const [key, m] of Object.entries(metrics)) {
+      if (!m) continue;
+      mHtml +=
+        '<div class="briefing-metric"><div class="briefing-metric-value">' +
+        fmtNum(m.current || 0) +
+        " " +
+        trendIndicator(m.current || 0, m.previous || 0) +
+        '</div><div class="briefing-metric-label">' +
+        esc(key) +
+        " today</div></div>";
+    }
+    if (b.active_agents && b.active_agents.length) {
+      mHtml +=
+        '<div class="briefing-metric"><div class="briefing-metric-value" style="font-size:13px">' +
+        b.active_agents.map((a) => agentTag(a)).join(" ") +
+        '</div><div class="briefing-metric-label">active agents</div></div>';
+    }
+    mEl.innerHTML = mHtml;
+
+    // Sparklines on stat cards
+    const sparks = b.sparklines || {};
+    if (sparks.sessions)
+      document.getElementById("sparkSessions").innerHTML = renderSparkline(
+        sparks.sessions,
+        "var(--accent)",
+      );
+    if (sparks.memories)
+      document.getElementById("sparkMemories").innerHTML = renderSparkline(
+        sparks.memories,
+        "var(--cyan)",
+      );
+    if (sparks.decisions)
+      document.getElementById("sparkDecisions").innerHTML = renderSparkline(
+        sparks.decisions,
+        "var(--purple)",
+      );
+
+    // Trend indicators on stat cards
+    if (metrics.sessions)
+      document.getElementById("trendSessions").innerHTML = trendIndicator(
+        metrics.sessions.current || 0,
+        metrics.sessions.previous || 0,
+      );
+    if (metrics.memories)
+      document.getElementById("trendMemories").innerHTML = trendIndicator(
+        metrics.memories.current || 0,
+        metrics.memories.previous || 0,
+      );
+    if (metrics.decisions)
+      document.getElementById("trendDecisions").innerHTML = trendIndicator(
+        metrics.decisions.current || 0,
+        metrics.decisions.previous || 0,
+      );
+
+    // Digest grid (merged from loadFullBriefing)
+    const digest = document.getElementById("briefingDigest");
+    let dHtml = "";
+    if (b.project_breakdown && b.project_breakdown.length) {
+      dHtml +=
+        '<div class="digest-card"><div class="digest-card-title">projects today</div><ul class="digest-list">';
+      b.project_breakdown.forEach((p) => {
+        let name = (p.project || "unknown").split("/").pop();
+        dHtml +=
+          "<li><strong>" +
+          esc(name) +
+          "</strong> &mdash; " +
+          (p.sessions || 0) +
+          " sessions, " +
+          fmtNum(p.tokens || 0) +
+          " tokens</li>";
+      });
+      dHtml += "</ul></div>";
+    }
+    if (b.decisions_today && b.decisions_today.length) {
+      dHtml +=
+        '<div class="digest-card"><div class="digest-card-title">decisions today</div><ul class="digest-list">';
+      b.decisions_today.slice(0, 5).forEach((d) => {
+        dHtml +=
+          "<li>" +
+          esc(d.what || "") +
+          (d.why
+            ? ' <span class="dim">&mdash; ' + esc(d.why) + "</span>"
+            : "") +
+          "</li>";
+      });
+      dHtml += "</ul></div>";
+    }
+    if (b.new_facts && b.new_facts.length) {
+      dHtml +=
+        '<div class="digest-card"><div class="digest-card-title">new facts learned</div><ul class="digest-list">';
+      b.new_facts.slice(0, 5).forEach((f) => {
+        dHtml +=
+          "<li><strong>" +
+          esc(f.subject || "") +
+          "</strong> " +
+          esc(f.predicate || "") +
+          " " +
+          esc(f.object || "") +
+          "</li>";
+      });
+      dHtml += "</ul></div>";
+    }
+    if (b.top_files && b.top_files.length) {
+      dHtml +=
+        '<div class="digest-card"><div class="digest-card-title">hottest files</div><ul class="digest-list">';
+      b.top_files.slice(0, 5).forEach((f) => {
+        let path = f.file_path || f.path || "";
+        let name = path.split("/").pop() || path;
+        dHtml +=
+          '<li><span style="color:var(--cyan)">' +
+          esc(name) +
+          "</span> &mdash; " +
+          (f.change_frequency || f.changes || 0) +
+          " changes</li>";
+      });
+      dHtml += "</ul></div>";
+    }
+    if (dHtml) {
+      digest.innerHTML = dHtml;
+      digest.style.display = "";
+    }
+  } catch (e) {
+    // Show welcome message on error
+    document.getElementById("briefingHeadline").innerHTML =
+      "<strong>Welcome to Remembrant</strong>";
+    document.getElementById("briefingMetrics").innerHTML =
+      '<div style="font-size:12px;color:var(--text-secondary)">Your AI agent activity will appear here once you ingest session data.</div>';
+    console.log("Briefing not available:", e.message);
+  }
+}
+
+async function loadAttention() {
+  let typeLabels = {
+    conflict: "Cross-agent conflict",
+    stale_memory: "Stale memory",
+    high_churn: "Frequently changed file",
+    contradictory_fact: "Contradicting facts",
+  };
+  try {
+    const data = await api("attention");
+    const items = data.items || [];
+    const bar = document.getElementById("attentionBar");
+    bar.style.display = "";
+    if (!items.length) {
+      bar.innerHTML =
+        '<div style="font-size:11px;color:var(--text-dim);padding:8px 0">&#x2713; No issues detected</div>';
+      return;
+    }
+    bar.innerHTML = items
+      .map((item) => {
+        const sev = item.severity || "medium";
+        const type = item.type || "unknown";
+        const label = typeLabels[type] || type.replace(/_/g, " ");
+        return (
+          '<div class="attention-item severity-' +
+          sev +
+          '">' +
+          '<div class="attention-type type-' +
+          type +
+          '">' +
+          esc(label) +
+          "</div>" +
+          '<div class="attention-title">' +
+          esc(item.title || "") +
+          "</div>" +
+          '<div class="attention-detail">' +
+          esc(item.detail || "") +
+          "</div></div>"
+        );
+      })
+      .join("");
+  } catch (e) {
+    console.log("Attention not available:", e.message);
+  }
+}
+
+// -----------------------------------------------------------------------
+// Tab navigation
+// -----------------------------------------------------------------------
+function switchTab(tab) {
+  document
+    .querySelectorAll(".nav-item")
+    .forEach((n) => n.classList.remove("active"));
+  document
+    .querySelectorAll(".tab-content")
+    .forEach((p) => p.classList.remove("active"));
+  const navEl = document.querySelector('.nav-item[data-tab="' + tab + '"]');
+  if (navEl) navEl.classList.add("active");
+  document.getElementById(tab + "Panel").classList.add("active");
+  if (tab === "home") {
+    loadBriefing();
+    loadAttention();
+    loadHomeActivity();
+  }
+  if (tab === "sessions") loadSessions(currentProject);
+  if (tab === "memories") loadMemories();
+  if (tab === "decisions") loadDecisions();
+  if (tab === "facts") loadFacts();
+  if (tab === "analytics") loadAnalytics();
+}
+
+// -----------------------------------------------------------------------
+// Stats
+// -----------------------------------------------------------------------
+async function loadStats() {
+  try {
+    const d = await api("stats");
+    let today = d.today || null;
+    function statHtml(todayVal, totalVal) {
+      if (today && typeof todayVal === "number") {
+        return (
+          fmtNum(todayVal) +
+          '</div><div style="font-size:10px;color:var(--text-dim)">' +
+          fmtNum(totalVal) +
+          " total"
+        );
+      }
+      return fmtNum(totalVal);
+    }
+    document.getElementById("statSessions").innerHTML = statHtml(
+      today ? today.sessions : null,
+      d.sessions || 0,
+    );
+    document.getElementById("statMemories").innerHTML = statHtml(
+      today ? today.memories : null,
+      d.memories || 0,
+    );
+    document.getElementById("statDecisions").innerHTML = statHtml(
+      today ? today.decisions : null,
+      d.decisions || 0,
+    );
+    document.getElementById("statToolCalls").innerHTML = statHtml(
+      today ? today.tool_calls : null,
+      d.tool_calls || 0,
+    );
+    document.getElementById("statProjects").textContent = d.projects || 0;
+    document.getElementById("navSessions").textContent = fmtNum(
+      d.sessions || 0,
+    );
+    document.getElementById("navMemories").textContent = fmtNum(
+      d.memories || 0,
+    );
+    document.getElementById("navDecisions").textContent = fmtNum(
+      d.decisions || 0,
+    );
+    document.getElementById("sbProjects").textContent =
+      (d.projects || 0) + " projects";
+    const factCount = d.active_facts ?? d.facts ?? 0;
+    document.getElementById("statFacts").textContent = fmtNum(factCount);
+    document.getElementById("navFacts").textContent = fmtNum(factCount);
+    document.getElementById("sbRefresh").textContent =
+      "updated " + new Date().toLocaleTimeString();
+  } catch (e) {
+    document.getElementById("statSessions").textContent = "ERR";
+  }
+}
+
+async function loadProjects() {
+  try {
+    const projects = await api("projects");
+    const sel = document.getElementById("projectFilter");
+    projects.forEach((p) => {
+      const o = document.createElement("option");
+      o.value = p;
+      o.textContent = p;
+      sel.appendChild(o);
+    });
+    document.getElementById("sbAgents").textContent =
+      projects.length + " projects tracked";
+  } catch (e) {
+    console.error("Projects:", e);
+  }
+}
+
+// -----------------------------------------------------------------------
+// Sessions
+// -----------------------------------------------------------------------
+async function loadSessions(project) {
+  try {
+    let url = "sessions?limit=200";
+    if (project) url += "&project=" + encodeURIComponent(project);
+    const sessions = await api(url);
+    allSessions = sessions;
+    document.getElementById("sessionsCount").textContent =
+      "(" + sessions.length + ")";
+    renderSessions(sessions);
+  } catch (e) {
+    document.getElementById("sessionsContent").innerHTML =
+      '<div class="empty-state"><div class="empty-icon">&#x2297;</div><div class="empty-text">Error: ' +
+      esc(String(e)) +
+      "</div></div>";
+  }
+}
+
+function getDayLabel(dateStr) {
+  try {
+    let d = parseUtcDate(dateStr);
+    let now = new Date();
+    let today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    let yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    let sessionDay = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    if (sessionDay.getTime() === today.getTime()) return "Today";
+    if (sessionDay.getTime() === yesterday.getTime()) return "Yesterday";
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  } catch {
+    return "";
+  }
+}
+
+function renderSessionItem(s) {
+  let agent = safeToken(s.agent);
+  let timeStr = s.started_at ? relTime(s.started_at) : "-";
+  let sum = s.summary || "\u2014";
+  let project = s.project_id ? s.project_id.split("/").pop() : "";
+  return (
+    '<div class="feed-item" onclick="showDetail(\'' +
+    jsArg(s.id) +
+    "')\">" +
+    '<div class="feed-icon feed-icon-' +
+    agent +
+    '">' +
+    (agent === "claude" || agent === "claude_code"
+      ? "&#x2318;"
+      : agent === "codex"
+        ? "&#x25C8;"
+        : "&#x25C6;") +
+    "</div>" +
+    '<div class="feed-body">' +
+    '<div class="feed-header"><span class="feed-agent" style="color:' +
+    (AGENT_COLORS[agent] || "var(--text-primary)") +
+    '">' +
+    esc(s.agent || "unknown") +
+    (project
+      ? ' <span class="dim" style="font-weight:400;font-size:10px">' +
+        esc(project) +
+        "</span>"
+      : "") +
+    "</span>" +
+    '<span class="feed-time">' +
+    timeStr +
+    "</span></div>" +
+    '<div class="feed-summary">' +
+    esc(sum) +
+    "</div>" +
+    '<div class="feed-meta">' +
+    (s.message_count
+      ? "<span>&#x2709; " + s.message_count + " msgs</span>"
+      : "") +
+    (s.tool_call_count
+      ? "<span>&#x2699; " + s.tool_call_count + " tools</span>"
+      : "") +
+    (s.total_tokens
+      ? "<span>&#x26A1; " + fmtNum(s.total_tokens) + " tokens</span>"
+      : "") +
+    (s.duration_minutes
+      ? "<span>&#x23F1; " + s.duration_minutes + "min</span>"
+      : "") +
+    "</div></div></div>"
+  );
+}
+
+function renderSessions(sessions) {
+  const filtered = sessions.filter((s) => activeAgents.has(safeToken(s.agent)));
+  const el = document.getElementById("sessionsContent");
+  if (!filtered.length) {
+    el.innerHTML =
+      '<div class="empty-state">' +
+      '<div class="empty-icon">&#x229E;</div>' +
+      '<div class="empty-title">No sessions yet</div>' +
+      '<div class="empty-desc">Sessions track your AI coding agent conversations. Start by ingesting agent data:</div>' +
+      '<div class="empty-commands"><code>rem ingest</code> <span class="cmd-comment"># Import all detected agent sessions</span></div></div>';
+    return;
+  }
+  let html = '<div class="activity-feed">';
+  let lastDay = "";
+  filtered.forEach((s) => {
+    let day = s.started_at ? getDayLabel(s.started_at) : "";
+    if (day && day !== lastDay) {
+      html += '<div class="feed-day-header">' + esc(day) + "</div>";
+      lastDay = day;
+    }
+    html += renderSessionItem(s);
+  });
+  html += "</div>";
+  el.innerHTML = html;
+}
+
+async function loadHomeActivity() {
+  try {
+    let url = "sessions?limit=10";
+    if (currentProject) url += "&project=" + encodeURIComponent(currentProject);
+    let sessions = await api(url);
+    let el = document.getElementById("homeActivityContent");
+    let filtered = sessions.filter((s) => activeAgents.has(safeToken(s.agent)));
+    if (!filtered.length) {
+      el.innerHTML =
+        '<div class="empty-state"><div class="empty-icon">&#x229E;</div><div class="empty-title">No recent activity</div>' +
+        '<div class="empty-desc">Ingest agent data to see activity here.</div></div>';
+      return;
+    }
+    let html = '<div class="activity-feed">';
+    let lastDay = "";
+    filtered.forEach((s) => {
+      let day = s.started_at ? getDayLabel(s.started_at) : "";
+      if (day && day !== lastDay) {
+        html += '<div class="feed-day-header">' + esc(day) + "</div>";
+        lastDay = day;
+      }
+      html += renderSessionItem(s);
+    });
+    html += "</div>";
+    el.innerHTML = html;
+  } catch (e) {
+    document.getElementById("homeActivityContent").innerHTML =
+      '<div class="empty-state"><div class="empty-icon">&#x2297;</div><div class="empty-text">Error loading activity</div></div>';
+  }
+  // Also load recent decisions for home
+  try {
+    let dUrl = "decisions";
+    if (currentProject)
+      dUrl += "?project=" + encodeURIComponent(currentProject);
+    let decisions = await api(dUrl);
+    let dEl = document.getElementById("homeDecisionsContent");
+    let recent = decisions.slice(0, 5);
+    if (!recent.length) {
+      dEl.innerHTML =
+        '<div class="empty-state" style="padding:20px"><div class="empty-title" style="font-size:12px">No decisions yet</div></div>';
+      return;
+    }
+    dEl.innerHTML = recent
+      .map((d) => {
+        let dt = d.created_at ? fmtDate(d.created_at) : "";
+        return (
+          '<div class="decision-card">' +
+          '<div class="card-meta"><span class="card-type">' +
+          esc(d.decision_type || "decision") +
+          '</span><span class="card-date">' +
+          dt +
+          "</span></div>" +
+          '<div class="card-body" style="color:var(--text-primary);font-weight:500">' +
+          esc(d.what) +
+          "</div>" +
+          (d.why
+            ? '<div class="card-body" style="margin-top:4px">\u21B3 ' +
+              esc(d.why) +
+              "</div>"
+            : "") +
+          "</div>"
+        );
+      })
+      .join("");
+  } catch (e) {
+    document.getElementById("homeDecisionsContent").innerHTML =
+      '<div class="empty-state" style="padding:20px"><div class="empty-text">Could not load decisions</div></div>';
+  }
+}
+
+function sortBy(field) {
+  if (sortField === field) sortAsc = !sortAsc;
+  else {
+    sortField = field;
+    sortAsc = true;
+  }
+  allSessions.sort((a, b) => {
+    const av = a[field] || "",
+      bv = b[field] || "";
+    return sortAsc ? (av > bv ? 1 : -1) : av < bv ? 1 : -1;
+  });
+  renderSessions(allSessions);
+}
+
+async function showDetail(id) {
+  try {
+    const data = await api("sessions/" + encodeURIComponent(id));
+    const s = data.session;
+    const tcs = data.tool_calls || [];
+    let html =
+      '<div class="detail-grid">' +
+      '<div class="detail-item"><label>id</label><div class="val dim" style="font-size:11px;word-break:break-all">' +
+      esc(s.id) +
+      "</div></div>" +
+      '<div class="detail-item"><label>agent</label><div class="val">' +
+      agentTag(s.agent) +
+      "</div></div>" +
+      '<div class="detail-item"><label>project</label><div class="val">' +
+      esc(s.project_id || "-") +
+      "</div></div>" +
+      '<div class="detail-item"><label>duration</label><div class="val">' +
+      (s.duration_minutes || "-") +
+      " min</div></div>" +
+      '<div class="detail-item"><label>started</label><div class="val mono">' +
+      fmtDateTime(s.started_at) +
+      "</div></div>" +
+      '<div class="detail-item"><label>ended</label><div class="val mono">' +
+      fmtDateTime(s.ended_at) +
+      "</div></div>" +
+      '<div class="detail-item"><label>messages</label><div class="val mono">' +
+      (s.message_count || "-") +
+      "</div></div>" +
+      '<div class="detail-item"><label>tokens</label><div class="val mono">' +
+      (s.total_tokens ? fmtNum(s.total_tokens) : "-") +
+      "</div></div></div>";
+    if (s.summary)
+      html +=
+        '<div style="margin-bottom:14px"><label style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:1px">summary</label><div style="margin-top:4px;color:var(--text-secondary);font-size:12px;line-height:1.6">' +
+        esc(s.summary) +
+        "</div></div>";
+    if (s.files_changed && s.files_changed.length)
+      html +=
+        '<div style="margin-bottom:14px"><label style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:1px">files changed (' +
+        s.files_changed.length +
+        ')</label><ul class="files-list">' +
+        s.files_changed.map((f) => "<li>" + esc(f) + "</li>").join("") +
+        "</ul></div>";
+    if (tcs.length) {
+      html +=
+        '<div><label style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:1px">tool calls (' +
+        tcs.length +
+        ")</label>";
+      tcs.slice(0, 50).forEach((tc) => {
+        const cls = tc.success === false ? " failed" : "";
+        const ts = tc.timestamp
+          ? parseUtcDate(tc.timestamp).toLocaleTimeString()
+          : "";
+        html +=
+          '<div class="tool-call-item' +
+          cls +
+          '"><div class="tc-header"><span>' +
+          esc(tc.tool_name || "unknown") +
+          '</span><span class="dim">' +
+          ts +
+          "</span></div>" +
+          (tc.command
+            ? '<div class="tc-cmd">' +
+              esc(tc.command.substring(0, 150)) +
+              (tc.command.length > 150 ? "\u2026" : "") +
+              "</div>"
+            : "") +
+          (tc.error_message
+            ? '<div class="tc-err">' + esc(tc.error_message) + "</div>"
+            : "") +
+          "</div>";
+      });
+      if (tcs.length > 50)
+        html +=
+          '<div class="dim" style="padding:8px;font-size:11px">...and ' +
+          (tcs.length - 50) +
+          " more</div>";
+      html += "</div>";
+    }
+    document.getElementById("modalTitle").textContent =
+      "Session \u2014 " + (s.agent || "");
+    document.getElementById("detailContent").innerHTML = html;
+    document.getElementById("detailModal").style.display = "block";
+  } catch (e) {
+    console.error("Detail:", e);
+  }
+}
+
+// -----------------------------------------------------------------------
+// Memories
+// -----------------------------------------------------------------------
+async function loadMemories() {
+  const el = document.getElementById("memoriesContent");
+  try {
+    let url = "memories?limit=200";
+    if (currentProject) url += "&project=" + encodeURIComponent(currentProject);
+    const memories = await api(url);
+    if (!memories.length) {
+      el.innerHTML =
+        '<div class="empty-state">' +
+        '<div class="empty-icon">&#x25C8;</div>' +
+        '<div class="empty-title">No memories extracted</div>' +
+        '<div class="empty-desc">Memories are automatically created when agents are ingested. They capture key learnings, patterns, and context.</div>' +
+        '<div class="empty-commands"><code>rem ingest</code> <span class="cmd-comment"># Memories are extracted automatically</span><br>' +
+        '<code>rem note &quot;My custom note&quot;</code> <span class="cmd-comment"># Or add a manual memory</span></div></div>';
+      return;
+    }
+    el.innerHTML = memories
+      .map((m) => {
+        const t = m.memory_type || "general";
+        const d = m.created_at ? fmtDate(m.created_at) : "";
+        const conf = typeof m.confidence === "number" ? m.confidence : 1.0;
+        return (
+          '<div class="memory-card" id="mem-' +
+          esc(m.id) +
+          '" data-tags="' +
+          esc((m.tags || []).join(", ")) +
+          '">' +
+          '<div class="card-meta"><span class="card-type">' +
+          esc(t) +
+          "</span>" +
+          '<div style="display:flex;align-items:center;gap:8px">' +
+          confBar(conf) +
+          '<span class="card-date">' +
+          d +
+          "</span>" +
+          '<div class="card-actions"><button onclick="editMemory(\'' +
+          jsArg(m.id) +
+          '\',event)" title="edit">&#x270E;</button><button class="del" onclick="deleteMemory(\'' +
+          jsArg(m.id) +
+          '\',event)" title="delete">&#x2715;</button></div>' +
+          "</div></div>" +
+          '<div class="card-body">' +
+          esc(m.content) +
+          "</div>" +
+          (m.project_id
+            ? '<div class="card-footer">project: ' +
+              esc(m.project_id) +
+              "</div>"
+            : "") +
+          memoryTags(m) +
+          "</div>"
+        );
+      })
+      .join("");
+  } catch (e) {
+    el.innerHTML =
+      '<div class="empty-state"><div class="empty-icon">&#x2297;</div><div class="empty-text">failed to load</div></div>';
+  }
+}
+
+async function editMemory(id, ev) {
+  ev.stopPropagation();
+  const card = document.getElementById("mem-" + id);
+  if (card.querySelector(".edit-form")) return;
+  const body = card.querySelector(".card-body");
+  const current = body.textContent;
+  const form = document.createElement("div");
+  form.className = "edit-form";
+  form.innerHTML =
+    "<textarea>" +
+    esc(current) +
+    "</textarea>" +
+    '<input type="text" class="tag-input" value="' +
+    esc(card.dataset.tags || "") +
+    '" placeholder="tags (comma-separated)" style="width:calc(100% - 22px);margin-top:6px;background:var(--bg-primary);border:1px solid var(--border);color:var(--text-primary);padding:7px;border-radius:4px;font-family:inherit;font-size:11px" />' +
+    '<div class="edit-row"><span style="font-size:10px;color:var(--text-dim)">confidence:</span><input type="range" min="0" max="100" value="80" id="confSlider-' +
+    id +
+    '"><span id="confVal-' +
+    id +
+    '" style="font-size:10px;color:var(--text-dim);width:30px">80%</span></div>' +
+    '<div style="display:flex;gap:6px;justify-content:flex-end;margin-top:8px"><button class="btn btn-sm btn-ghost" onclick="this.closest(\'.edit-form\').remove()">cancel</button><button class="btn btn-sm" onclick="saveMemory(\'' +
+    esc(id) +
+    "',this)\">save</button></div>";
+  card.appendChild(form);
+  const slider = form.querySelector("input[type=range]");
+  const valEl = form.querySelector("[id^=confVal]");
+  slider.oninput = () => {
+    valEl.textContent = slider.value + "%";
+  };
+}
+
+async function saveMemory(id, btn) {
+  const form = btn.closest(".edit-form");
+  const content = form.querySelector("textarea").value;
+  const conf = parseInt(form.querySelector("input[type=range]").value) / 100;
+  const tags = (form.querySelector(".tag-input").value || "")
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+  try {
+    await apiPut("memories/" + encodeURIComponent(id), {
+      content,
+      confidence: conf,
+      tags,
+    });
+    loadMemories();
+  } catch (e) {
+    alert("Failed: " + e.message);
+  }
+}
+
+async function deleteMemory(id, ev) {
+  ev.stopPropagation();
+  if (!confirm("Delete this memory?")) return;
+  try {
+    await apiDel("memories/" + encodeURIComponent(id));
+    loadMemories();
+  } catch (e) {
+    alert("Failed: " + e.message);
+  }
+}
+
+// -----------------------------------------------------------------------
+// Facts
+// -----------------------------------------------------------------------
+async function loadFacts() {
+  const el = document.getElementById("factsContent");
+  el.innerHTML = '<div class="loading-state">loading</div>';
+  try {
+    const url = "facts?limit=200&active_only=" + factsActiveOnly;
+    if (currentProject) url += "&project=" + encodeURIComponent(currentProject);
+    const facts = await api(url);
+    document.getElementById("factsCount").textContent =
+      "(" + facts.length + ")";
+    if (!facts.length) {
+      el.innerHTML =
+        '<div class="empty-state">' +
+        '<div class="empty-icon">&#x25C6;</div>' +
+        '<div class="empty-title">Knowledge base is empty</div>' +
+        '<div class="empty-desc">Facts are structured knowledge triples (subject-predicate-object) that agents learn and share across sessions.</div>' +
+        '<div class="empty-commands"><span class="cmd-comment"># Facts are auto-extracted during ingestion, or add manually:</span><br>' +
+        "<code>rem ingest</code> to distill facts from agent sessions.</div></div>";
+      return;
+    }
+    el.innerHTML =
+      "<table><thead><tr><th>subject</th><th>predicate</th><th>object</th><th>confidence</th><th>agent</th><th>status</th></tr></thead><tbody>" +
+      facts
+        .map((f) => {
+          const active = !f.invalid_at;
+          const cls = active ? "fact-active" : "fact-inactive";
+          return (
+            '<tr class="' +
+            cls +
+            '" onclick="showFactHistory(\'' +
+            jsArg(f.id) +
+            '\')" style="cursor:pointer">' +
+            "<td" +
+            (active ? "" : ' class="fact-superseded"') +
+            ">" +
+            esc(f.subject) +
+            "</td>" +
+            '<td class="dim">' +
+            esc(f.predicate) +
+            "</td>" +
+            "<td" +
+            (active ? "" : ' class="fact-superseded"') +
+            ">" +
+            esc(f.object) +
+            "</td>" +
+            "<td>" +
+            confBar(f.confidence || 1.0) +
+            "</td>" +
+            '<td class="dim">' +
+            esc(f.source_agent || "-") +
+            "</td>" +
+            '<td><span class="status-badge">' +
+            (active ? "active" : "superseded") +
+            "</span></td></tr>"
+          );
+        })
+        .join("") +
+      "</tbody></table>";
+  } catch (e) {
+    el.innerHTML =
+      '<div class="empty-state"><div class="empty-icon">&#x2297;</div><div class="empty-text">failed to load facts</div></div>';
+  }
+}
+
+function toggleFactsFilter() {
+  factsActiveOnly = !factsActiveOnly;
+  document.getElementById("factsToggle").textContent = factsActiveOnly
+    ? "active only"
+    : "show all";
+  loadFacts();
+}
+
+async function showFactHistory(id) {
+  try {
+    const history = await api("facts/" + encodeURIComponent(id) + "/history");
+    if (!Array.isArray(history) || !history.length) {
+      alert("No history found");
+      return;
+    }
+    const subject = history[0].subject;
+    let html =
+      '<h3 style="font-size:13px;margin-bottom:12px;color:var(--text-secondary)">Evolution of: <span style="color:var(--accent)">' +
+      esc(subject) +
+      "</span></h3>";
+    html += '<div class="timeline">';
+    history.forEach((f, i) => {
+      const active = !f.invalid_at;
+      const prev = i > 0 ? history[i - 1] : null;
+      html +=
+        '<div class="timeline-item' +
+        (active ? "" : " superseded") +
+        '">' +
+        '<div class="timeline-meta">' +
+        fmtDateTime(f.valid_at || f.created_at) +
+        "<br>" +
+        '<span style="color:' +
+        (active ? "var(--accent)" : "var(--text-dim)") +
+        '">' +
+        (active ? "ACTIVE" : "superseded") +
+        "</span>" +
+        (f.source_agent ? "<br>" + esc(f.source_agent) : "") +
+        "</div>" +
+        '<div class="timeline-content">' +
+        (prev && prev.object !== f.object
+          ? '<div class="timeline-diff-del">' +
+            esc(prev.predicate) +
+            " " +
+            esc(prev.object) +
+            "</div>"
+          : "") +
+        "<div" +
+        (prev && prev.object !== f.object ? ' class="timeline-diff-add"' : "") +
+        ">" +
+        esc(f.predicate) +
+        " <strong>" +
+        esc(f.object) +
+        "</strong></div>" +
+        '<div style="margin-top:4px">' +
+        confBar(f.confidence || 1.0) +
+        "</div>" +
+        "</div></div>";
+    });
+    html += "</div>";
+    document.getElementById("factModalTitle").textContent =
+      "Fact History \u2014 " + subject;
+    document.getElementById("factModalContent").innerHTML = html;
+    document.getElementById("factModal").style.display = "block";
+  } catch (e) {
+    console.error("Fact history:", e);
+  }
+}
+
+// -----------------------------------------------------------------------
+// Decisions
+// -----------------------------------------------------------------------
+async function loadDecisions() {
+  const el = document.getElementById("decisionsContent");
+  try {
+    let url = "decisions";
+    if (currentProject) url += "?project=" + encodeURIComponent(currentProject);
+    const decisions = await api(url);
+    if (!decisions.length) {
+      el.innerHTML =
+        '<div class="empty-state">' +
+        '<div class="empty-icon">&#x2298;</div>' +
+        '<div class="empty-title">No decisions recorded</div>' +
+        '<div class="empty-desc">Decisions capture the &quot;what&quot; and &quot;why&quot; of choices made by AI agents during coding sessions.</div>' +
+        '<div class="empty-commands">Use <strong>+ record</strong> to add the first decision.</div></div>';
+      return;
+    }
+    el.innerHTML = decisions
+      .map((d) => {
+        const dt = d.created_at ? fmtDate(d.created_at) : "";
+        return (
+          '<div class="decision-card">' +
+          '<div class="card-meta"><span class="card-type">' +
+          esc(d.decision_type || "decision") +
+          '</span><span class="card-date">' +
+          dt +
+          "</span></div>" +
+          '<div class="card-body" style="color:var(--text-primary);font-weight:500">' +
+          esc(d.what) +
+          "</div>" +
+          (d.why
+            ? '<div class="card-body" style="margin-top:4px">\u21B3 ' +
+              esc(d.why) +
+              "</div>"
+            : "") +
+          (d.alternatives && d.alternatives.length
+            ? '<div class="card-footer">alternatives: ' +
+              d.alternatives.map(esc).join(" \u00B7 ") +
+              "</div>"
+            : "") +
+          (d.project_id
+            ? '<div class="card-footer">project: ' +
+              esc(d.project_id) +
+              "</div>"
+            : "") +
+          "</div>"
+        );
+      })
+      .join("");
+  } catch (e) {
+    el.innerHTML =
+      '<div class="empty-state"><div class="empty-icon">&#x2297;</div><div class="empty-text">failed to load</div></div>';
+  }
+}
+
+// -----------------------------------------------------------------------
+// Analytics
+// -----------------------------------------------------------------------
+const chartDefaults = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      labels: {
+        color: "#8b949e",
+        font: { family: "JetBrains Mono", size: 10 },
+      },
+    },
+  },
+  scales: {
+    x: {
+      ticks: { color: "#484f58", font: { family: "JetBrains Mono", size: 9 } },
+      grid: { color: "#21262d" },
+    },
+    y: {
+      ticks: { color: "#484f58", font: { family: "JetBrains Mono", size: 9 } },
+      grid: { color: "#21262d" },
+    },
+  },
+};
+
+async function loadAnalytics() {
+  await Promise.all([
+    loadAgentStats(),
+    loadTimeline(),
+    loadToolStats(),
+    loadHotfiles(),
+  ]);
+}
+
+async function loadAgentStats() {
+  try {
+    const agents = await api("stats/agents");
+    if (!Array.isArray(agents)) return;
+    // Metric cards
+    const el = document.getElementById("agentMetrics");
+    el.innerHTML = agents
+      .map((a) => {
+        const color =
+          AGENT_COLORS[a.agent?.toLowerCase()] || "var(--text-primary)";
+        return (
+          '<div class="metric-card"><div class="metric-agent" style="color:' +
+          color +
+          '">' +
+          esc(a.agent) +
+          "</div>" +
+          '<div class="metric-val">' +
+          fmtNum(a.sessions || 0) +
+          '</div><div class="metric-label">sessions</div>' +
+          '<div style="margin-top:8px;font-size:12px;color:var(--text-secondary)">' +
+          fmtNum(a.total_tokens || 0) +
+          " tokens</div>" +
+          '<div class="metric-label">' +
+          (a.avg_duration ? Math.round(a.avg_duration) + " min avg" : "-") +
+          "</div></div>"
+        );
+      })
+      .join("");
+    // Doughnut chart
+    if (charts.agent) charts.agent.destroy();
+    charts.agent = new Chart(document.getElementById("agentChart"), {
+      type: "doughnut",
+      data: {
+        labels: agents.map((a) => a.agent),
+        datasets: [
+          {
+            data: agents.map((a) => a.sessions || 0),
+            backgroundColor: agents.map(
+              (a) => AGENT_COLORS[a.agent?.toLowerCase()] || "#8b949e",
+            ),
+            borderWidth: 0,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            position: "right",
+            labels: {
+              color: "#8b949e",
+              font: { family: "JetBrains Mono", size: 10 },
+              padding: 12,
+            },
+          },
+        },
+      },
+    });
+    // Token bar chart
+    if (charts.token) charts.token.destroy();
+    charts.token = new Chart(document.getElementById("tokenChart"), {
+      type: "bar",
+      data: {
+        labels: agents.map((a) => a.agent),
+        datasets: [
+          {
+            label: "Tokens",
+            data: agents.map((a) => a.total_tokens || 0),
+            backgroundColor: agents.map(
+              (a) => AGENT_COLORS[a.agent?.toLowerCase()] || "#8b949e",
+            ),
+            borderRadius: 4,
+          },
+        ],
+      },
+      options: {
+        ...chartDefaults,
+        indexAxis: "y",
+        plugins: { ...chartDefaults.plugins, legend: { display: false } },
+      },
+    });
+  } catch (e) {
+    console.error("Agent stats:", e);
+  }
+}
+
+async function loadTimeline() {
+  try {
+    const data = await api("stats/timeline?days=30");
+    if (!Array.isArray(data) || !data.length) return;
+    const dates = [...new Set(data.map((d) => d.date))].sort();
+    const agentNames = [...new Set(data.map((d) => d.agent))];
+    const datasets = agentNames.map((agent) => ({
+      label: agent,
+      data: dates.map((date) => {
+        const m = data.find((d) => d.date === date && d.agent === agent);
+        return m ? m.count : 0;
+      }),
+      borderColor: AGENT_COLORS[agent?.toLowerCase()] || "#8b949e",
+      backgroundColor: (AGENT_COLORS[agent?.toLowerCase()] || "#8b949e") + "33",
+      fill: true,
+      tension: 0.3,
+      borderWidth: 2,
+      pointRadius: 1,
+    }));
+    if (charts.timeline) charts.timeline.destroy();
+    charts.timeline = new Chart(document.getElementById("timelineChart"), {
+      type: "line",
+      data: {
+        labels: dates.map((d) => {
+          return formatIsoDay(d);
+        }),
+        datasets,
+      },
+      options: {
+        ...chartDefaults,
+        plugins: {
+          ...chartDefaults.plugins,
+          legend: {
+            labels: {
+              color: "#8b949e",
+              font: { family: "JetBrains Mono", size: 10 },
+            },
+          },
+        },
+      },
+    });
+  } catch (e) {
+    console.error("Timeline:", e);
+  }
+}
+
+async function loadToolStats() {
+  try {
+    const tools = await api("stats/tools");
+    if (!Array.isArray(tools) || !tools.length) return;
+    const top10 = tools.slice(0, 10);
+    const colors = [
+      "#00ff9c",
+      "#58a6ff",
+      "#bc8cff",
+      "#ffa657",
+      "#ff7b72",
+      "#e3b341",
+      "#79c0ff",
+      "#7ee787",
+      "#d2a8ff",
+      "#ffa198",
+    ];
+    if (charts.tool) charts.tool.destroy();
+    charts.tool = new Chart(document.getElementById("toolChart"), {
+      type: "doughnut",
+      data: {
+        labels: top10.map((t) => t.tool_name || "unknown"),
+        datasets: [
+          {
+            data: top10.map((t) => t.count || 0),
+            backgroundColor: colors,
+            borderWidth: 0,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            position: "right",
+            labels: {
+              color: "#8b949e",
+              font: { family: "JetBrains Mono", size: 9 },
+              padding: 8,
+            },
+          },
+        },
+      },
+    });
+    // Table
+    const el = document.getElementById("toolStatsContent");
+    el.innerHTML =
+      "<table><thead><tr><th>tool</th><th>calls</th><th>success rate</th><th>avg duration</th></tr></thead><tbody>" +
+      tools
+        .map((t) => {
+          const rate =
+            t.count > 0 ? Math.round((t.success_count / t.count) * 100) : 0;
+          const rateColor =
+            rate >= 90
+              ? "var(--accent)"
+              : rate >= 70
+                ? "var(--yellow)"
+                : "var(--red)";
+          return (
+            "<tr><td>" +
+            esc(t.tool_name || "unknown") +
+            '</td><td class="mono">' +
+            fmtNum(t.count) +
+            "</td>" +
+            '<td class="mono" style="color:' +
+            rateColor +
+            '">' +
+            rate +
+            "%</td>" +
+            '<td class="mono dim">' +
+            (t.avg_duration_ms ? Math.round(t.avg_duration_ms) + "ms" : "-") +
+            "</td></tr>"
+          );
+        })
+        .join("") +
+      "</tbody></table>";
+  } catch (e) {
+    console.error("Tool stats:", e);
+  }
+}
+
+async function loadHotfiles() {
+  try {
+    const files = await api("hotfiles?limit=15");
+    if (!Array.isArray(files) || !files.length) return;
+    if (charts.hotfile) charts.hotfile.destroy();
+    const labels = files.map((f) => {
+      const p = f.file_path || f[0] || "";
+      return p.length > 40 ? "..." + p.slice(-37) : p;
+    });
+    const data = files.map((f) => f.change_frequency || f[1] || 0);
+    charts.hotfile = new Chart(document.getElementById("hotfileChart"), {
+      type: "bar",
+      data: {
+        labels,
+        datasets: [
+          {
+            label: "Changes",
+            data,
+            backgroundColor: "#00ff9c44",
+            borderColor: "#00ff9c",
+            borderWidth: 1,
+            borderRadius: 3,
+          },
+        ],
+      },
+      options: {
+        ...chartDefaults,
+        indexAxis: "y",
+        plugins: { ...chartDefaults.plugins, legend: { display: false } },
+        scales: {
+          ...chartDefaults.scales,
+          y: {
+            ...chartDefaults.scales.y,
+            ticks: {
+              ...chartDefaults.scales.y.ticks,
+              font: { family: "JetBrains Mono", size: 8 },
+            },
+          },
+        },
+      },
+    });
+  } catch (e) {
+    console.error("Hotfiles:", e);
+  }
+}
+
+// -----------------------------------------------------------------------
+// Search
+// -----------------------------------------------------------------------
+function setSearchMode(mode) {
+  searchMode = mode;
+  document
+    .querySelectorAll(".mode-btn")
+    .forEach((b) => b.classList.toggle("active", b.dataset.mode === mode));
+  const input = document.getElementById("searchInput");
+  if (mode === "xpath") input.placeholder = '//Session[node~"auth"]/Decision';
+  else if (mode === "facts")
+    input.placeholder = "search facts by subject or object...";
+  else input.placeholder = "search sessions, memories, facts...";
+}
+
+function toggleAgent(el, agent) {
+  el.classList.toggle("active");
+  if (activeAgents.has(agent)) activeAgents.delete(agent);
+  else activeAgents.add(agent);
+  renderSessions(allSessions);
+}
+
+async function performSearch() {
+  const q = document.getElementById("searchInput").value.trim();
+  if (!q) return;
+  const el = document.getElementById("searchContent");
+  el.innerHTML = '<div class="loading-state">searching</div>';
+  document.getElementById("navSearchItem").style.display = "";
+  switchTab("search");
+
+  try {
+    const eq = encodeURIComponent(q);
+    let html = "";
+    if (searchMode === "xpath") {
+      const response = await api("search/xpath?q=" + eq + "&limit=20");
+      const results = Array.isArray(response?.results) ? response.results : [];
+      if (results.length) {
+        html +=
+          '<div class="section-label">xpath results (' +
+          results.length +
+          ")</div>";
+        results.forEach((r) => {
+          html +=
+            '<div class="memory-card"><div class="card-meta"><span class="card-type">' +
+            esc(r.node_type || r.result_type || "node") +
+            "</span>" +
+            '<span class="card-date">score: ' +
+            (r.weight || r.score || 0).toFixed(2) +
+            "</span></div>" +
+            '<div class="card-body">' +
+            esc(r.name || r.content || "") +
+            "</div>" +
+            (r.path
+              ? '<div class="card-footer">path: ' +
+                r.path.map(esc).join(" \u2192 ") +
+                "</div>"
+              : "") +
+            "</div>";
+        });
+      } else
+        html =
+          '<div class="empty-state"><div class="empty-icon">&#x2295;</div><div class="empty-text">no XPath results for "' +
+          esc(q) +
+          '"</div></div>';
+    } else if (searchMode === "facts") {
+      const facts = await api("search/facts?q=" + eq);
+      if (Array.isArray(facts) && facts.length) {
+        html += '<div class="section-label">facts (' + facts.length + ")</div>";
+        facts.forEach((f) => {
+          const active = !f.invalid_at;
+          html +=
+            '<div class="memory-card" style="border-left-color:var(--orange)"><div class="card-meta"><span class="card-type" style="color:var(--orange)">fact</span>' +
+            '<span class="status-badge">' +
+            (active ? "active" : "superseded") +
+            "</span></div>" +
+            '<div class="card-body"><strong>' +
+            esc(f.subject) +
+            "</strong> " +
+            esc(f.predicate) +
+            " <strong>" +
+            esc(f.object) +
+            "</strong></div>" +
+            '<div class="card-footer">' +
+            confBar(f.confidence || 1.0) +
+            "</div></div>";
+        });
+      } else
+        html =
+          '<div class="empty-state"><div class="empty-icon">&#x2295;</div><div class="empty-text">no facts matching "' +
+          esc(q) +
+          '"</div></div>';
+    } else {
+      const [sessions, memories] = await Promise.all([
+        api("search/sessions?q=" + eq),
+        api("search/memories?q=" + eq),
+      ]);
+      if (sessions.length) {
+        html +=
+          '<div class="section-label">sessions (' + sessions.length + ")</div>";
+        sessions.forEach((s) => {
+          const dt = s.started_at ? fmtDate(s.started_at) : "";
+          html +=
+            '<div class="memory-card" style="cursor:pointer;border-left-color:var(--blue)" onclick="showDetail(\'' +
+            jsArg(s.id) +
+            "')\">" +
+            '<div class="card-meta"><div style="display:flex;gap:6px;align-items:center">' +
+            agentTag(s.agent) +
+            '<span class="dim">' +
+            esc(s.project_id || "") +
+            '</span></div><span class="card-date">' +
+            dt +
+            "</span></div>" +
+            '<div class="card-body">' +
+            esc(s.summary || "\u2014") +
+            "</div></div>";
+        });
+      }
+      if (memories.length) {
+        html +=
+          '<div class="section-label">memories (' + memories.length + ")</div>";
+        memories.forEach((m) => {
+          html +=
+            '<div class="memory-card"><div class="card-meta"><span class="card-type">' +
+            esc(m.memory_type || "general") +
+            '</span></div><div class="card-body">' +
+            esc(m.content) +
+            "</div>" +
+            memoryTags(m) +
+            "</div>";
+        });
+      }
+      if (!sessions.length && !memories.length)
+        html =
+          '<div class="empty-state"><div class="empty-icon">&#x2295;</div><div class="empty-text">no results for "' +
+          esc(q) +
+          '"</div></div>';
+    }
+    el.innerHTML = html;
+  } catch (e) {
+    el.innerHTML =
+      '<div class="empty-state"><div class="empty-icon">&#x2297;</div><div class="empty-text">search failed: ' +
+      esc(e.message) +
+      "</div></div>";
+  }
+}
+
+function clearSearch() {
+  document.getElementById("searchInput").value = "";
+  document.getElementById("navSearchItem").style.display = "none";
+  switchTab("sessions");
+}
+
+// -----------------------------------------------------------------------
+// Add Note / Decision
+// -----------------------------------------------------------------------
+function showAddNote() {
+  document.getElementById("noteModal").style.display = "block";
+  document.getElementById("noteText").focus();
+}
+function showAddDecision() {
+  document.getElementById("decisionModal").style.display = "block";
+  document.getElementById("decWhat").focus();
+}
+
+async function submitNote() {
+  const text = document.getElementById("noteText").value.trim();
+  if (!text) return;
+  const tags = document
+    .getElementById("noteTags")
+    .value.split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+  try {
+    await apiPost("notes", {
+      text,
+      tags,
+      project: currentProject || undefined,
+    });
+    document.getElementById("noteText").value = "";
+    document.getElementById("noteTags").value = "";
+    closeModal("noteModal");
+    loadMemories();
+  } catch (e) {
+    alert("Failed: " + e.message);
+  }
+}
+
+async function submitDecision() {
+  const what = document.getElementById("decWhat").value.trim();
+  const why = document.getElementById("decWhy").value.trim();
+  if (!what) return;
+  try {
+    await apiPost("decisions", {
+      what,
+      why: why || undefined,
+      project: currentProject || undefined,
+    });
+    document.getElementById("decWhat").value = "";
+    document.getElementById("decWhy").value = "";
+    closeModal("decisionModal");
+    loadDecisions();
+  } catch (e) {
+    alert("Failed: " + e.message);
+  }
+}
+
+// -----------------------------------------------------------------------
+// Modals & Command Palette
+// -----------------------------------------------------------------------
+function closeModal(id) {
+  document.getElementById(id).style.display = "none";
+}
+
+function openCmdPalette() {
+  document.getElementById("cmdPalette").style.display = "block";
+  const input = document.getElementById("cmdInput");
+  input.value = "";
+  input.focus();
+}
+function closeCmdPalette() {
+  document.getElementById("cmdPalette").style.display = "none";
+}
+
+function cmdGo(tab) {
+  closeCmdPalette();
+  switchTab(tab);
+}
+
+// -----------------------------------------------------------------------
+// Keyboard shortcuts
+// -----------------------------------------------------------------------
+document.addEventListener("keydown", (e) => {
+  // Cmd+K or Ctrl+K → command palette
+  if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+    e.preventDefault();
+    openCmdPalette();
+    return;
+  }
+  // Escape → close modals
+  if (e.key === "Escape") {
+    if (document.getElementById("cmdPalette").style.display === "block") {
+      closeCmdPalette();
+      return;
+    }
+    document
+      .querySelectorAll(".modal-overlay")
+      .forEach((m) => (m.style.display = "none"));
+    return;
+  }
+  // Don't handle shortcuts when typing in inputs
+  if (
+    e.target.tagName === "INPUT" ||
+    e.target.tagName === "TEXTAREA" ||
+    e.target.tagName === "SELECT"
+  )
+    return;
+  // / → focus search
+  if (e.key === "/") {
+    e.preventDefault();
+    document.getElementById("searchInput").focus();
+  }
+});
+
+document.getElementById("searchInput").addEventListener("keydown", (e) => {
+  if (e.key === "Enter") performSearch();
+});
+
+document.getElementById("cmdInput").addEventListener("keydown", (e) => {
+  if (e.key === "Escape") closeCmdPalette();
+  if (e.key === "Enter") {
+    const val = e.target.value.trim().toLowerCase();
+    const tabs = [
+      "home",
+      "sessions",
+      "memories",
+      "facts",
+      "decisions",
+      "analytics",
+    ];
+    const match = tabs.find((t) => t.startsWith(val));
+    if (match) cmdGo(match);
+    else {
+      closeCmdPalette();
+      document.getElementById("searchInput").value = e.target.value;
+      performSearch();
+    }
+  }
+});
+
+document.getElementById("cmdPalette").addEventListener("click", (e) => {
+  if (e.target === document.getElementById("cmdPalette")) closeCmdPalette();
+});
+document.querySelectorAll(".modal-overlay").forEach((m) =>
+  m.addEventListener("click", (e) => {
+    if (e.target === m) m.style.display = "none";
+  }),
+);
+
+document.getElementById("projectFilter").addEventListener("change", (e) => {
+  currentProject = e.target.value;
+  loadSessions(currentProject);
+});
+
+// -----------------------------------------------------------------------
+// Init
+// -----------------------------------------------------------------------
+switchTab("home");
+loadStats();
+loadProjects();

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -1,0 +1,1180 @@
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+fn rem(home: &std::path::Path, args: &[&str]) -> Result<std::process::Output> {
+    Command::new(env!("CARGO_BIN_EXE_rem"))
+        .args(args)
+        .env("HOME", home)
+        .env("RUST_LOG", "warn")
+        .output()
+        .with_context(|| format!("failed to run rem {}", args.join(" ")))
+}
+
+fn assert_rem_success(home: &std::path::Path, args: &[&str]) -> Result<std::process::Output> {
+    let output = rem(home, args)?;
+    if !output.status.success() {
+        bail!(
+            "`rem {}` failed ({})\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+    Ok(output)
+}
+
+fn create_claude_fixture(home: &std::path::Path) -> Result<()> {
+    let project = home.join(".claude").join("projects").join("e2e-project");
+    std::fs::create_dir_all(project.join("memory"))?;
+
+    let now = chrono::Utc::now();
+    let created = now.to_rfc3339();
+    let modified = (now + chrono::Duration::seconds(45)).to_rfc3339();
+    let index = json!({
+        "version": 1,
+        "entries": [{
+            "sessionId": "e2e-session-001",
+            "fullPath": project.join("e2e-session-001.jsonl"),
+            "firstPrompt": "Refactor authentication",
+            "summary": "E2E authentication refactor session",
+            "messageCount": 0,
+            "created": created,
+            "modified": modified,
+            "gitBranch": "main",
+            "projectPath": "/tmp/e2e-project",
+            "isSidechain": false
+        }]
+    });
+    std::fs::write(project.join("sessions-index.json"), index.to_string())?;
+
+    let transcript_lines = [
+        json!({
+            "type": "user",
+            "message": {"role": "user", "content": "Refactor authentication"},
+            "timestamp": created
+        }),
+        json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "tool_use",
+                    "id": "tool-write-1",
+                    "name": "Write",
+                    "input": {"file_path": "src/auth.rs", "content": "pub fn login() {}"}
+                }],
+                "usage": {"input_tokens": 120, "output_tokens": 80}
+            },
+            "timestamp": created
+        }),
+        json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Refactored the auth boundary."}],
+                "usage": {"input_tokens": 200, "output_tokens": 140}
+            },
+            "timestamp": modified
+        }),
+    ];
+    let mut transcript = std::fs::File::create(project.join("e2e-session-001.jsonl"))?;
+    for line in transcript_lines {
+        writeln!(transcript, "{line}")?;
+    }
+
+    std::fs::write(
+        project.join("memory").join("MEMORY.md"),
+        "# Project memory\n\n- Authentication lives behind the auth boundary.\n",
+    )?;
+    Ok(())
+}
+
+async fn spawn_fake_embedding_server() -> Result<(String, tokio::task::JoinHandle<()>)> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("http://127.0.0.1:{}/v1", listener.local_addr()?.port());
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut request = Vec::new();
+                let mut chunk = [0_u8; 4096];
+                loop {
+                    let read = match socket.read(&mut chunk).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => read,
+                    };
+                    request.extend_from_slice(&chunk[..read]);
+                    let headers_end = request
+                        .windows(b"\r\n\r\n".len())
+                        .position(|window| window == b"\r\n\r\n");
+                    if let Some(headers_end) = headers_end {
+                        let headers = String::from_utf8_lossy(&request[..headers_end]).to_string();
+                        let content_length = headers
+                            .lines()
+                            .find_map(|line| {
+                                let (name, value) = line.split_once(':')?;
+                                name.eq_ignore_ascii_case("content-length")
+                                    .then(|| value.trim().parse::<usize>().ok())
+                                    .flatten()
+                            })
+                            .unwrap_or(0);
+                        if request.len() >= headers_end + 4 + content_length {
+                            break;
+                        }
+                    }
+                }
+
+                let _ = request;
+                let body = json!({
+                    "object": "list",
+                    "model": "test-embedding",
+                    "data": [{
+                        "object": "embedding",
+                        "index": 0,
+                        "embedding": [0.1, -0.2, 0.3, -0.4]
+                    }]
+                })
+                .to_string();
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.shutdown().await;
+            });
+        }
+    });
+    Ok((endpoint, server))
+}
+
+#[tokio::test]
+async fn configured_jsonl_agent_end_to_end_workflow() -> Result<()> {
+    let home = tempfile::tempdir()?;
+    let artifact_dir = home.path().join("agent-data").join("custom-project");
+    std::fs::create_dir_all(&artifact_dir)?;
+    std::fs::write(
+        artifact_dir.join("session.jsonl"),
+        concat!(
+            "{\"sessionId\":\"dynamic-session-001\",\"timestamp\":\"2026-08-21T18:00:00Z\",\"kind\":\"message\",\"message\":{\"text\":\"Dynamic adapter works\"}}\n",
+            "{\"sessionId\":\"dynamic-session-001\",\"timestamp\":\"2026-08-21T18:01:00Z\",\"kind\":\"tool\",\"tool\":{\"name\":\"Edit\"},\"message\":{\"text\":\"src/custom.rs\"}}\n"
+        ),
+    )?;
+
+    let config_dir = home.path().join(".remembrant");
+    std::fs::create_dir_all(&config_dir)?;
+    std::fs::write(
+        config_dir.join("config.yaml"),
+        format!(
+            r#"storage:
+  duckdb_path: {home}/.remembrant/remembrant.duckdb
+  lancedb_path: {home}/.remembrant/lancedb
+agents:
+  claude_code:
+    enabled: false
+    path: {home}/.claude
+  codex:
+    enabled: false
+    path: {home}/.codex
+  gemini:
+    enabled: false
+    path: {home}/.gemini
+  dynamic:
+    - id: custom_jsonl
+      display_name: Custom JSONL Agent
+      enabled: true
+      path: {home}/agent-data
+      adapter_type: jsonl
+      jsonl:
+        file_pattern: "**/*.jsonl"
+        session_id_path: sessionId
+        timestamp_path: timestamp
+        content_path: message.text
+        tool_name_path: tool.name
+        tool_call_type: kind=tool
+"#,
+            home = home.path().display()
+        ),
+    )?;
+
+    let initialized = assert_rem_success(home.path(), &["init"])?;
+    let stdout = String::from_utf8_lossy(&initialized.stdout);
+    assert!(stdout.contains("Custom JSONL Agent"), "{stdout}");
+    assert!(stdout.contains("1 sessions"), "{stdout}");
+
+    let recent = assert_rem_success(home.path(), &["recent", "--limit", "10"])?;
+    let recent_stdout = String::from_utf8_lossy(&recent.stdout);
+    assert!(
+        recent_stdout.contains("dynamic-session-001"),
+        "{recent_stdout}"
+    );
+    let row = recent_stdout
+        .lines()
+        .find(|line| line.contains("dynamic-session-001"))
+        .context("dynamic session row missing")?;
+    let columns: Vec<_> = row.split_whitespace().collect();
+    assert_eq!(columns[1], "custom_jsonl", "{recent_stdout}");
+    assert_eq!(columns[4], "2", "{recent_stdout}");
+    assert_eq!(columns[5], "1", "{recent_stdout}");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cli_and_dashboard_end_to_end_workflow() -> Result<()> {
+    let home = tempfile::tempdir()?;
+    create_claude_fixture(home.path())?;
+
+    let ingest = assert_rem_success(home.path(), &["ingest", "--skip-embed", "--skip-distill"])?;
+    let ingest_stdout = String::from_utf8_lossy(&ingest.stdout);
+    assert!(ingest_stdout.contains("1 sessions"), "{ingest_stdout}");
+
+    assert!(
+        home.path()
+            .join(".remembrant")
+            .join("config.yaml")
+            .is_file()
+    );
+    assert!(
+        home.path()
+            .join(".remembrant")
+            .join("remembrant.duckdb")
+            .is_file()
+    );
+
+    let recent = assert_rem_success(home.path(), &["recent", "--limit", "10"])?;
+    let recent_stdout = String::from_utf8_lossy(&recent.stdout);
+    assert!(recent_stdout.contains("e2e-session-001"), "{recent_stdout}");
+
+    let recent_by_project = assert_rem_success(
+        home.path(),
+        &["recent", "--limit", "10", "--project", "e2e-project"],
+    )?;
+    assert!(String::from_utf8_lossy(&recent_by_project.stdout).contains("e2e-session-001"));
+    let recent_wrong_agent = assert_rem_success(
+        home.path(),
+        &["recent", "--limit", "10", "--agent", "codex"],
+    )?;
+    assert!(!String::from_utf8_lossy(&recent_wrong_agent.stdout).contains("e2e-session-001"));
+
+    let note = assert_rem_success(
+        home.path(),
+        &[
+            "note",
+            "Keep the authentication boundary explicit",
+            "--project",
+            "e2e-project",
+            "--tag",
+            "auth-pattern",
+        ],
+    )?;
+    assert!(String::from_utf8_lossy(&note.stdout).contains("Note saved:"));
+    let tagged = assert_rem_success(home.path(), &["find", "auth-pattern"])?;
+    let tagged_stdout = String::from_utf8_lossy(&tagged.stdout);
+    assert!(
+        tagged_stdout.contains("Keep the authentication boundary explicit"),
+        "{tagged_stdout}"
+    );
+
+    let search = assert_rem_success(home.path(), &["search", "authentication", "--json"])?;
+    let search_value: Value = serde_json::from_slice(&search.stdout)?;
+    assert!(search_value["count"].as_u64().unwrap_or(0) >= 1);
+    assert!(search_value["results"].as_array().is_some_and(|results| {
+        results
+            .iter()
+            .any(|result| result["content"] == "E2E authentication refactor session")
+    }));
+
+    let filtered = assert_rem_success(
+        home.path(),
+        &[
+            "search",
+            "authentication",
+            "--json",
+            "--project",
+            "e2e-project",
+            "--agent",
+            "claude_code",
+            "--type",
+            "session",
+            "--since",
+            "1d",
+        ],
+    )?;
+    let filtered_value: Value = serde_json::from_slice(&filtered.stdout)?;
+    assert_eq!(filtered_value["count"].as_u64(), Some(1));
+
+    let exact = assert_rem_success(
+        home.path(),
+        &[
+            "search",
+            "E2E authentication refactor session",
+            "--exact",
+            "--json",
+            "--content-type",
+            "session",
+        ],
+    )?;
+    let exact_value: Value = serde_json::from_slice(&exact.stdout)?;
+    assert_eq!(exact_value["count"].as_u64(), Some(1));
+
+    let invalid_since = rem(
+        home.path(),
+        &["search", "authentication", "--since", "not-a-date"],
+    )?;
+    assert!(!invalid_since.status.success());
+    assert!(String::from_utf8_lossy(&invalid_since.stderr).contains("invalid --since value"));
+
+    let xpath = assert_rem_success(home.path(), &["xpath", "//Session", "--json"])?;
+    let xpath_value: Value = serde_json::from_slice(&xpath.stdout)?;
+    assert!(
+        xpath_value["count"].as_u64().unwrap_or(0) >= 1,
+        "XPath response: {xpath_value}"
+    );
+
+    let xpath_tree = assert_rem_success(
+        home.path(),
+        &[
+            "xpath",
+            "//Session",
+            "--depth",
+            "2",
+            "--limit",
+            "1",
+            "--tree",
+        ],
+    )?;
+    assert!(String::from_utf8_lossy(&xpath_tree.stdout).contains("Path: Root -> "));
+
+    // Exercise the remaining default-build read/report commands against the
+    // same isolated database.
+    let status = assert_rem_success(home.path(), &["status"])?;
+    assert!(String::from_utf8_lossy(&status.stdout).contains("Remembrant Status"));
+
+    let stats = assert_rem_success(home.path(), &["stats"])?;
+    assert!(String::from_utf8_lossy(&stats.stdout).contains("Sessions:    1"));
+
+    let brief = assert_rem_success(home.path(), &["brief", "--today", "--json"])?;
+    let brief_value: Value = serde_json::from_slice(&brief.stdout)?;
+    assert_eq!(brief_value["sessions"].as_array().map(Vec::len), Some(1));
+
+    let project_brief = assert_rem_success(
+        home.path(),
+        &["brief", "--today", "--json", "--project", "e2e-project"],
+    )?;
+    let project_brief_value: Value = serde_json::from_slice(&project_brief.stdout)?;
+    assert_eq!(
+        project_brief_value["sessions"].as_array().map(Vec::len),
+        Some(1)
+    );
+
+    let agent_brief = assert_rem_success(
+        home.path(),
+        &["brief", "--for-agent", "--json", "--max-tokens", "500"],
+    )?;
+    let agent_brief_value: Value = serde_json::from_slice(&agent_brief.stdout)?;
+    assert!(agent_brief_value.is_object());
+
+    let context = assert_rem_success(
+        home.path(),
+        &[
+            "context",
+            "authentication",
+            "--project",
+            "e2e-project",
+            "--json",
+            "--max-tokens",
+            "500",
+        ],
+    )?;
+    let context_value: Value = serde_json::from_slice(&context.stdout)?;
+    assert!(context_value.is_object());
+
+    let consolidated = assert_rem_success(
+        home.path(),
+        &["consolidate", "--project", "e2e-project", "--json"],
+    )?;
+    let consolidated_value: Value = serde_json::from_slice(&consolidated.stdout)?;
+    assert!(consolidated_value["decay_scores"].is_array());
+
+    let patterns = assert_rem_success(home.path(), &["patterns", "authentication"])?;
+    assert!(String::from_utf8_lossy(&patterns.stdout).contains("No patterns found."));
+
+    let decisions = assert_rem_success(home.path(), &["decisions", "--all"])?;
+    assert!(String::from_utf8_lossy(&decisions.stdout).contains("No decisions found."));
+
+    let related = assert_rem_success(home.path(), &["related", "src/auth.rs"])?;
+    assert!(String::from_utf8_lossy(&related.stdout).contains("Related to: src/auth.rs"));
+
+    let graph = assert_rem_success(home.path(), &["graph", "src/auth.rs"])?;
+    assert!(String::from_utf8_lossy(&graph.stdout).contains("[USED_IN]"));
+
+    let timeline_since = (chrono::Utc::now() - chrono::Duration::days(1)).to_rfc3339();
+    let timeline = assert_rem_success(
+        home.path(),
+        &["timeline", "authentication", "--since", &timeline_since],
+    )?;
+    assert!(String::from_utf8_lossy(&timeline.stdout).contains("Timeline: authentication"));
+
+    let export_path = home.path().join("export.json");
+    let exported = assert_rem_success(
+        home.path(),
+        &[
+            "export",
+            "--project",
+            "e2e-project",
+            "--format",
+            "json",
+            "--output",
+            export_path.to_str().context("export path UTF-8")?,
+        ],
+    )?;
+    assert!(String::from_utf8_lossy(&exported.stdout).contains("Exported to"));
+    let export_value: Value = serde_json::from_str(&std::fs::read_to_string(&export_path)?)?;
+    assert_eq!(export_value["sessions"].as_array().map(Vec::len), Some(1));
+
+    let markdown = assert_rem_success(
+        home.path(),
+        &["export", "--project", "e2e-project", "--format", "markdown"],
+    )?;
+    assert!(String::from_utf8_lossy(&markdown.stdout).contains("# Project Memory"));
+
+    let gc = assert_rem_success(home.path(), &["gc"])?;
+    assert!(String::from_utf8_lossy(&gc.stdout).contains("Deleted 0 sessions"));
+
+    let invalid_threshold = rem(
+        home.path(),
+        &[
+            "consolidate",
+            "--project",
+            "e2e-project",
+            "--threshold",
+            "1.5",
+        ],
+    )?;
+    assert!(!invalid_threshold.status.success());
+    assert!(String::from_utf8_lossy(&invalid_threshold.stderr).contains("between 0.0 and 1.0"));
+
+    let invalid_export = rem(home.path(), &["export", "--format", "yaml"])?;
+    assert!(!invalid_export.status.success());
+    assert!(String::from_utf8_lossy(&invalid_export.stderr).contains("unsupported export format"));
+
+    let empty_note = rem(home.path(), &["note", "   "])?;
+    assert!(!empty_note.status.success());
+    assert!(String::from_utf8_lossy(&empty_note.stderr).contains("cannot be empty"));
+
+    let analysis_repo = home.path().join("analysis-repo");
+    std::fs::create_dir_all(&analysis_repo)?;
+    std::fs::write(
+        analysis_repo.join("lib.rs"),
+        "pub fn e2e_identity(value: usize) -> usize { value }\n",
+    )?;
+    let analysis_repo = analysis_repo.to_string_lossy().to_string();
+    #[cfg(feature = "code-analysis")]
+    let analysis = assert_rem_success(
+        home.path(),
+        &["analyze", &analysis_repo, "--project", "e2e-analysis"],
+    )?;
+    #[cfg(feature = "code-analysis")]
+    assert!(
+        String::from_utf8_lossy(&analysis.stdout).contains("Symbols extracted: 1"),
+        "analysis output missing"
+    );
+    #[cfg(not(feature = "code-analysis"))]
+    {
+        let analysis = rem(home.path(), &["analyze", &analysis_repo])?;
+        assert!(!analysis.status.success());
+        assert!(
+            String::from_utf8_lossy(&analysis.stderr)
+                .contains("requires the 'code-analysis' feature")
+        );
+    }
+
+    // Exercise repository embedding through a real local OpenAI-compatible
+    // HTTP endpoint, including forced replacement via --update.
+    let (embedding_endpoint, embedding_server) = spawn_fake_embedding_server().await?;
+    let config_path = home.path().join(".remembrant").join("config.yaml");
+    let config_text = std::fs::read_to_string(&config_path)?;
+    let config_text = config_text
+        .replace(
+            "endpoint: http://localhost:1234/v1",
+            &format!("endpoint: {embedding_endpoint}"),
+        )
+        .replace("dimensions: 768", "dimensions: 4");
+    std::fs::write(&config_path, config_text)?;
+
+    let repository = home.path().join("embedded-repo");
+    std::fs::create_dir_all(&repository)?;
+    std::fs::write(
+        repository.join("main.rs"),
+        "fn main() { println!(\"embedding e2e\"); }\n",
+    )?;
+    let repository = repository.to_string_lossy().to_string();
+    let embedded = assert_rem_success(home.path(), &["embed", &repository])?;
+    assert!(
+        String::from_utf8_lossy(&embedded.stdout).contains("Chunks: 1 created, 1 embedded"),
+        "embedding output missing"
+    );
+
+    std::fs::write(
+        home.path().join("embedded-repo").join("main.rs"),
+        "fn main() { println!(\"embedding changed\"); }\n",
+    )?;
+    let updated_embeddings = assert_rem_success(home.path(), &["embed", &repository, "--update"])?;
+    assert!(
+        String::from_utf8_lossy(&updated_embeddings.stdout)
+            .contains("Chunks: 1 created, 1 embedded"),
+        "updated embedding output missing"
+    );
+    embedding_server.abort();
+
+    // Exercise the real event-driven watcher path, then shut it down with the
+    // same SIGTERM mechanism used by `rem stop`.
+    let mut watcher = Command::new(env!("CARGO_BIN_EXE_rem"))
+        .args(["watch"])
+        .env("HOME", home.path())
+        .env("RUST_LOG", "warn")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let stdout = watcher.stdout.take().context("watcher stdout missing")?;
+    let stderr = watcher.stderr.take().context("watcher stderr missing")?;
+    let (line_tx, line_rx) = mpsc::channel::<String>();
+    let stderr_line_tx = line_tx.clone();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            if line_tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            if stderr_line_tx.send(format!("[stderr] {line}")).is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut ready = false;
+    for _ in 0..100 {
+        if let Ok(line) = line_rx.recv_timeout(Duration::from_millis(200))
+            && line.contains("Press Ctrl+C to stop")
+            && line.contains("Event watching 1 native artifact director")
+        {
+            ready = true;
+            break;
+        }
+    }
+    assert!(ready, "watcher did not start");
+    // Give the recursive filesystem watcher time to finish registration after
+    // the daemon's readiness line is printed.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let append_timestamp = (chrono::Utc::now() + chrono::Duration::seconds(90)).to_rfc3339();
+    let append_event = json!({
+        "type": "user",
+        "message": {"role": "user", "content": "Watch this authentication update"},
+        "timestamp": append_timestamp
+    });
+    let transcript_path = home
+        .path()
+        .join(".claude")
+        .join("projects")
+        .join("e2e-project")
+        .join("e2e-session-001.jsonl");
+    {
+        let mut transcript = std::fs::read_to_string(&transcript_path)?;
+        transcript.push('\n');
+        transcript.push_str(&append_event.to_string());
+        transcript.push('\n');
+        std::fs::write(&transcript_path, transcript)?;
+    }
+
+    let mut ingested = false;
+    for _ in 0..100 {
+        if let Ok(line) = line_rx.recv_timeout(Duration::from_millis(200))
+            && line.contains("ingested 1 changed session(s)")
+        {
+            ingested = true;
+            break;
+        }
+    }
+    let watcher_diagnostics: Vec<_> = line_rx.try_iter().collect();
+    assert!(
+        ingested,
+        "watcher did not ingest the transcript update; output so far: {watcher_diagnostics:?}"
+    );
+
+    let duplicate_watch = rem(home.path(), &["watch"])?;
+    assert!(!duplicate_watch.status.success());
+    assert!(String::from_utf8_lossy(&duplicate_watch.stderr).contains("already running"));
+
+    // Reap the child concurrently so `process_is_running` does not mistake a
+    // briefly unreaped zombie for a still-active watcher.
+    let watcher_wait = std::thread::spawn(move || watcher.wait());
+    let stopped = assert_rem_success(home.path(), &["stop"])?;
+    assert!(String::from_utf8_lossy(&stopped.stdout).contains("Daemon stopped"));
+    let watcher_status = watcher_wait
+        .join()
+        .map_err(|_| anyhow::anyhow!("watcher wait thread panicked"))??;
+    assert!(watcher_status.success());
+    assert!(
+        !home.path().join(".remembrant").join("daemon.pid").exists(),
+        "watcher should remove its PID file on SIGTERM"
+    );
+
+    let updated_recent = assert_rem_success(home.path(), &["recent", "--limit", "10"])?;
+    let updated_recent_stdout = String::from_utf8_lossy(&updated_recent.stdout);
+    let updated_row = updated_recent_stdout
+        .lines()
+        .find(|line| line.contains("e2e-session-001"))
+        .context("updated session row missing")?;
+    let updated_columns: Vec<_> = updated_row.split_whitespace().collect();
+    assert_eq!(updated_columns[4], "4", "{updated_recent_stdout}");
+    assert_eq!(updated_columns[5], "1", "{updated_recent_stdout}");
+
+    // Start the dashboard on an OS-selected free port so parallel tests cannot collide.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    let mut server = Command::new(env!("CARGO_BIN_EXE_rem"))
+        .args(["web", "--port", &port.to_string()])
+        .env("HOME", home.path())
+        .env("RUST_LOG", "warn")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()?;
+
+    let mut healthy = false;
+    for _ in 0..100 {
+        if let Ok(response) = client.get(&base).send().await {
+            healthy = response.status().is_success();
+            if healthy {
+                break;
+            }
+        }
+        if let Some(status) = server.try_wait()? {
+            bail!("dashboard exited early with status {status}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(healthy, "dashboard did not become healthy");
+
+    let index_response = client.get(&base).send().await?.error_for_status()?;
+    assert_eq!(
+        index_response
+            .headers()
+            .get(reqwest::header::CACHE_CONTROL)
+            .and_then(|value| value.to_str().ok()),
+        Some("no-store")
+    );
+    let index_html = index_response.text().await?;
+    assert!(index_html.contains("Remembrant"));
+    assert!(index_html.contains("/assets/dashboard.css"));
+    assert!(index_html.contains("/assets/dashboard.js"));
+    for integrity in [
+        "sha384-8dbf0940c6cca015338166ad7dee823800a2da58dc0dd650d8ec5ccc60376c635e59efba0c284c4c125e99e77b667bc9",
+        "sha384-d45b78fc94cd6eded2ff8e15d218a6a5c8f1f987d0d5ae96e9260124cafde1b6ba8f06615a85a82da66c326b4920b82a",
+        "sha384-b2c5333d05e32c72cedfd6bd022bb0c679f20f122f38c531110a6a7eb794696ee32c4743017885e94a286513b9dc5e99",
+    ] {
+        assert!(
+            index_html.contains(integrity),
+            "missing CDN integrity {integrity}"
+        );
+    }
+
+    let css_response = client
+        .get(format!("{base}/assets/dashboard.css"))
+        .send()
+        .await?
+        .error_for_status()?;
+    assert!(
+        css_response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .is_some_and(|value| value
+                .to_str()
+                .is_ok_and(|value| value.starts_with("text/css")))
+    );
+    assert_eq!(
+        css_response
+            .headers()
+            .get(reqwest::header::CACHE_CONTROL)
+            .and_then(|value| value.to_str().ok()),
+        Some("no-cache")
+    );
+    let js_response = client
+        .get(format!("{base}/assets/dashboard.js"))
+        .send()
+        .await?
+        .error_for_status()?;
+    assert!(
+        js_response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .is_some_and(|value| value
+                .to_str()
+                .is_ok_and(|value| value.starts_with("application/javascript")))
+    );
+    assert_eq!(
+        js_response
+            .headers()
+            .get(reqwest::header::CACHE_CONTROL)
+            .and_then(|value| value.to_str().ok()),
+        Some("no-cache")
+    );
+
+    let stats: Value = client
+        .get(format!("{base}/api/stats"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(stats["sessions"].as_u64(), Some(1));
+    assert_eq!(stats["today"]["sessions"].as_u64(), Some(1));
+    assert_eq!(stats["projects"].as_u64(), Some(1));
+    assert_eq!(stats["facts"].as_u64(), Some(0));
+    assert_eq!(stats["active_facts"].as_u64(), Some(0));
+
+    let sessions: Value = client
+        .get(format!("{base}/api/sessions"))
+        .query(&[("limit", "20")])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(sessions[0]["id"].as_str(), Some("e2e-session-001"));
+    assert_eq!(
+        sessions[0]["files_changed"][0].as_str(),
+        Some("src/auth.rs")
+    );
+
+    let bounded_sessions: Value = client
+        .get(format!("{base}/api/sessions"))
+        .query(&[("limit", "0")])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(bounded_sessions.as_array().map(Vec::len), Some(1));
+
+    let detail: Value = client
+        .get(format!("{base}/api/sessions/e2e-session-001"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(detail["session"]["total_tokens"].as_i64(), Some(540));
+    assert_eq!(detail["tool_calls"].as_array().map(Vec::len), Some(1));
+
+    let briefing: Value = client
+        .get(format!("{base}/api/briefing"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(briefing["metrics"]["sessions"]["current"].as_u64(), Some(1));
+    assert_eq!(briefing["metrics"]["tokens"]["current"].as_i64(), Some(540));
+    assert_eq!(
+        briefing["sparklines"]["sessions"].as_array().map(Vec::len),
+        Some(7)
+    );
+    assert!(
+        briefing["top_files"]
+            .as_array()
+            .is_some_and(|files| files.iter().any(|file| file["file_path"] == "src/auth.rs"))
+    );
+
+    let xpath_api: Value = client
+        .get(format!("{base}/api/search/xpath"))
+        .query(&[("q", "//Session"), ("limit", "20")])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(xpath_api["count"].as_u64(), Some(1));
+    assert!(
+        xpath_api["results"]
+            .as_array()
+            .is_some_and(|results| results.len() == 1)
+    );
+
+    let attention: Value = client
+        .get(format!("{base}/api/attention"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert!(attention["items"].is_array());
+
+    let note: Value = client
+        .post(format!("{base}/api/notes"))
+        .json(&json!({
+            "text": "E2E editable note",
+            "project": "e2e-project",
+            "tags": ["e2e-tag"]
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let note_id = note["id"].as_str().context("note id missing")?.to_string();
+    assert_eq!(note["tags"][0], "e2e-tag");
+
+    let empty_api_note = client
+        .post(format!("{base}/api/notes"))
+        .json(&json!({"text": "   "}))
+        .send()
+        .await?;
+    assert_eq!(empty_api_note.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let memories: Value = client
+        .get(format!("{base}/api/memories"))
+        .query(&[("project", "e2e-project")])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert!(memories.as_array().is_some_and(|items| {
+        items
+            .iter()
+            .any(|memory| memory["id"] == note_id && memory["content"] == "E2E editable note")
+    }));
+
+    let tagged_memories: Value = client
+        .get(format!("{base}/api/memories"))
+        .query(&[("tag", "e2e-tag"), ("project", "e2e-project")])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert!(
+        tagged_memories
+            .as_array()
+            .is_some_and(|items| items.iter().any(|memory| memory["id"] == note_id))
+    );
+
+    let updated_response = client
+        .put(format!("{base}/api/memories/{note_id}"))
+        .json(&json!({
+            "content": "E2E edited note",
+            "confidence": 0.75,
+            "tags": ["edited-tag"]
+        }))
+        .send()
+        .await?;
+    let updated_status = updated_response.status();
+    let updated_body = updated_response.text().await?;
+    assert!(
+        updated_status.is_success(),
+        "memory update failed ({updated_status}): {updated_body}"
+    );
+    let updated: Value = serde_json::from_str(&updated_body)?;
+    assert_eq!(updated["ok"].as_bool(), Some(true));
+
+    let updated_detail_response = client
+        .get(format!("{base}/api/memories/{note_id}"))
+        .send()
+        .await?;
+    let updated_detail_status = updated_detail_response.status();
+    let updated_detail_body = updated_detail_response.text().await?;
+    assert!(
+        updated_detail_status.is_success(),
+        "memory detail failed ({updated_detail_status}): {updated_detail_body}"
+    );
+    let updated_detail: Value = serde_json::from_str(&updated_detail_body)?;
+    assert_eq!(updated_detail["tags"][0], "edited-tag");
+
+    let empty_api_decision = client
+        .post(format!("{base}/api/decisions"))
+        .json(&json!({"what": "   "}))
+        .send()
+        .await?;
+    assert_eq!(
+        empty_api_decision.status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+
+    let deleted: Value = client
+        .delete(format!("{base}/api/memories/{note_id}"))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(deleted["ok"].as_bool(), Some(true));
+    let missing = client
+        .get(format!("{base}/api/memories/{note_id}"))
+        .send()
+        .await?;
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let decision: Value = client
+        .post(format!("{base}/api/decisions"))
+        .json(&json!({
+            "what": "Use UTC day boundaries",
+            "why": "Stored timestamps are UTC",
+            "alternatives": ["local boundaries"],
+            "project": "e2e-project"
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert!(decision["id"].is_string());
+
+    let decisions: Value = client
+        .get(format!("{base}/api/decisions"))
+        .query(&[("project", "e2e-project")])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert!(decisions.as_array().is_some_and(|items| {
+        items
+            .iter()
+            .any(|item| item["what"] == "Use UTC day boundaries")
+    }));
+
+    server.kill()?;
+    server.wait()?;
+
+    let nonempty_decisions = assert_rem_success(
+        home.path(),
+        &["decisions", "--project", "e2e-project", "--all"],
+    )?;
+    assert!(String::from_utf8_lossy(&nonempty_decisions.stdout).contains("Use UTC day boundaries"));
+
+    // Cover the MCP stdio transport end to end: modern discovery, protocol
+    // negotiation, legacy compatibility, deterministic tool discovery, and a
+    // mutating tool call against the same isolated database.
+    let mut mcp = Command::new(env!("CARGO_BIN_EXE_rem"))
+        .args(["mcp"])
+        .env("HOME", home.path())
+        .env("RUST_LOG", "warn")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let mut mcp_stdin = mcp.stdin.take().context("MCP stdin missing")?;
+    let mut mcp_stdout = BufReader::new(mcp.stdout.take().context("MCP stdout missing")?);
+
+    let read_mcp_response = |reader: &mut BufReader<std::process::ChildStdout>| -> Result<Value> {
+        let mut line = String::new();
+        let bytes = reader.read_line(&mut line)?;
+        if bytes == 0 {
+            bail!("MCP server closed stdout before responding");
+        }
+        serde_json::from_str(line.trim()).context("invalid MCP JSON-RPC response")
+    };
+
+    let modern_meta = json!({
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {}
+    });
+    writeln!(
+        mcp_stdin,
+        "{}",
+        json!({"jsonrpc": "1.0", "id": 0, "method": "ping"})
+    )?;
+    let invalid_jsonrpc = read_mcp_response(&mut mcp_stdout)?;
+    assert_eq!(invalid_jsonrpc["id"], 0);
+    assert_eq!(invalid_jsonrpc["error"]["code"], -32600);
+
+    writeln!(
+        mcp_stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "server/discover",
+            "params": {"_meta": modern_meta}
+        })
+    )?;
+    let discovery = read_mcp_response(&mut mcp_stdout)?;
+    let discovery_result = &discovery["result"];
+    assert_eq!(discovery_result["supportedVersions"][0], "2026-07-28");
+    assert_eq!(discovery_result["resultType"], "complete");
+    assert_eq!(discovery_result["cacheScope"], "public");
+    assert!(
+        discovery_result["ttlMs"]
+            .as_u64()
+            .is_some_and(|ttl| ttl > 0)
+    );
+
+    writeln!(
+        mcp_stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "server/discover",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "1900-01-01",
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        })
+    )?;
+    let unsupported = read_mcp_response(&mut mcp_stdout)?;
+    assert_eq!(unsupported["error"]["code"], -32022);
+    assert_eq!(unsupported["error"]["data"]["supported"][0], "2026-07-28");
+
+    writeln!(
+        mcp_stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 99,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28"
+                }
+            }
+        })
+    )?;
+    let invalid_metadata = read_mcp_response(&mut mcp_stdout)?;
+    assert_eq!(invalid_metadata["id"], 99);
+    assert_eq!(invalid_metadata["error"]["code"], -32602);
+
+    writeln!(
+        mcp_stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "legacy-client", "version": "1.0"}
+            }
+        })
+    )?;
+    let initialize = read_mcp_response(&mut mcp_stdout)?;
+    assert_eq!(initialize["result"]["protocolVersion"], "2024-11-05");
+
+    // `initialized` is a notification and MUST not produce a JSON-RPC response.
+    writeln!(
+        mcp_stdin,
+        "{}",
+        json!({"jsonrpc": "2.0", "method": "initialized"})
+    )?;
+    writeln!(
+        mcp_stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/list",
+            "params": {}
+        })
+    )?;
+    let legacy_tools = read_mcp_response(&mut mcp_stdout)?;
+    assert_eq!(legacy_tools["id"], 4);
+    assert!(legacy_tools["result"]["tools"].as_array().is_some());
+
+    writeln!(
+        mcp_stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/list",
+            "params": {"_meta": modern_meta}
+        })
+    )?;
+    let modern_tools = read_mcp_response(&mut mcp_stdout)?;
+    let modern_tool_result = &modern_tools["result"];
+    assert_eq!(modern_tool_result["resultType"], "complete");
+    assert_eq!(modern_tool_result["cacheScope"], "public");
+    assert!(
+        modern_tool_result["ttlMs"]
+            .as_u64()
+            .is_some_and(|ttl| ttl > 0)
+    );
+    let tool_names: Vec<&str> = modern_tool_result["tools"]
+        .as_array()
+        .context("MCP tools array missing")?
+        .iter()
+        .filter_map(|tool| tool["name"].as_str())
+        .collect();
+    let mut sorted_tool_names = tool_names.clone();
+    sorted_tool_names.sort_unstable();
+    assert_eq!(tool_names, sorted_tool_names);
+
+    writeln!(
+        mcp_stdin,
+        "{}",
+        json!({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {
+                "name": "mem_add",
+                    "arguments": {
+                        "type": "note",
+                        "text": "MCP E2E token is durable",
+                        "project": "e2e-project"
+                },
+                "_meta": modern_meta
+            },
+        })
+    )?;
+    let tool_call = read_mcp_response(&mut mcp_stdout)?;
+    assert_eq!(tool_call["result"]["resultType"], "complete");
+    assert_eq!(tool_call["result"]["isError"], Value::Null);
+    assert!(
+        tool_call["result"]["content"][0]["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("MCP E2E token is durable"))
+    );
+
+    drop(mcp_stdin);
+    let mcp_status = mcp.wait()?;
+    assert!(mcp_status.success());
+    let durable = assert_rem_success(home.path(), &["find", "MCP E2E token"])?;
+    assert!(String::from_utf8_lossy(&durable.stdout).contains("MCP E2E token"));
+
+    let forgotten = assert_rem_success(home.path(), &["forget", "--session", "e2e-session-001"])?;
+    assert!(String::from_utf8_lossy(&forgotten.stdout).contains("Session e2e-session-001 deleted"));
+    let recent_after_forget = assert_rem_success(home.path(), &["recent", "--limit", "10"])?;
+    assert!(
+        !String::from_utf8_lossy(&recent_after_forget.stdout).contains("e2e-session-001"),
+        "forgotten session is still displayed"
+    );
+    let duplicate_forget = rem(home.path(), &["forget", "--session", "e2e-session-001"])?;
+    assert!(!duplicate_forget.status.success());
+    assert!(String::from_utf8_lossy(&duplicate_forget.stderr).contains("not found"));
+
+    Ok(())
+}

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -8,7 +8,7 @@ description = "Core engine for Remembrant: ingestion, storage, search, and graph
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-serde_yaml.workspace = true
+serde_norway.workspace = true
 tokio.workspace = true
 arrow-array.workspace = true
 arrow-schema.workspace = true
@@ -18,7 +18,6 @@ tracing.workspace = true
 chrono.workspace = true
 uuid.workspace = true
 duckdb.workspace = true
-# kuzu.workspace = true  # TODO: re-enable when Rust SDK stabilizes
 lancedb.workspace = true
 futures.workspace = true
 notify.workspace = true
@@ -26,6 +25,7 @@ notify-debouncer-mini.workspace = true
 sha2.workspace = true
 reqwest.workspace = true
 regex.workspace = true
+glob.workspace = true
 dirs.workspace = true
 rusqlite = { workspace = true, optional = true }
 infiniloom-engine = { path = "../../infiniloom/engine", optional = true }

--- a/engine/src/code_analysis.rs
+++ b/engine/src/code_analysis.rs
@@ -4,11 +4,12 @@
 use anyhow::{Context, Result};
 use chrono::Utc;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Instant;
 use tracing::{debug, info, warn};
 
+use crate::graph_builder::GraphBackend;
 use crate::store::duckdb::{AnalysisRun, CodeDependency, CodeSymbol as DuckCodeSymbol, DuckStore};
-use crate::store::graph::{EdgeKind, GraphEdge, GraphNode, GraphStoreBackend, NodeKind};
 
 // Import Infiniloom types
 use infiniloom_engine::index::builder::IndexBuilder;
@@ -24,6 +25,7 @@ pub struct CodeAnalyzer {
 }
 
 /// Result of a code analysis operation
+#[derive(Debug)]
 pub struct AnalysisResult {
     pub files_analyzed: usize,
     pub symbols_extracted: usize,
@@ -44,7 +46,7 @@ impl CodeAnalyzer {
     pub fn analyze(
         &self,
         store: &DuckStore,
-        graph_store: &impl GraphStoreBackend,
+        graph_store: &impl GraphBackend,
     ) -> Result<AnalysisResult> {
         let start = Instant::now();
 
@@ -223,7 +225,7 @@ impl CodeAnalyzer {
         &self,
         index: &SymbolIndex,
         dep_graph: &DepGraph,
-        graph_store: &impl GraphStoreBackend,
+        graph_store: &impl GraphBackend,
     ) -> Result<(usize, usize)> {
         let mut nodes_added = 0;
         let mut edges_added = 0;
@@ -257,20 +259,18 @@ impl CodeAnalyzer {
                 properties.insert("docstring".to_string(), doc.clone());
             }
 
-            let node = GraphNode {
-                id: node_id.clone(),
-                kind: NodeKind::Symbol,
-                name: symbol.name.clone(),
-                properties,
-            };
-
-            graph_store.add_node(&node)?;
+            graph_store.add_node(
+                &node_id,
+                "Symbol",
+                &symbol.name,
+                &serde_json::to_string(&properties).unwrap_or_else(|_| "{}".to_string()),
+            )?;
             nodes_added += 1;
         }
 
         // Create CodeEntity nodes for each file
         for file in &index.files {
-            let node_id = format!("file:{}", file.path);
+            let node_id = format!("file:{}:{}", self.project_id, file.path);
 
             let mut properties = std::collections::HashMap::new();
             properties.insert("path".to_string(), file.path.clone());
@@ -278,14 +278,12 @@ impl CodeAnalyzer {
             properties.insert("lines".to_string(), file.lines.to_string());
             properties.insert("tokens".to_string(), file.tokens.to_string());
 
-            let node = GraphNode {
-                id: node_id.clone(),
-                kind: NodeKind::CodeEntity,
-                name: file.path.clone(),
-                properties,
-            };
-
-            graph_store.add_node(&node)?;
+            graph_store.add_node(
+                &node_id,
+                "CodeEntity",
+                &file.path,
+                &serde_json::to_string(&properties).unwrap_or_else(|_| "{}".to_string()),
+            )?;
             nodes_added += 1;
 
             // Create Defines edges from file to symbols
@@ -296,14 +294,7 @@ impl CodeAnalyzer {
                         self.project_id, file.path, symbol.name, symbol.span.start_line
                     );
 
-                    let edge = GraphEdge {
-                        from_id: node_id.clone(),
-                        to_id: symbol_id,
-                        kind: EdgeKind::Defines,
-                        properties: std::collections::HashMap::new(),
-                    };
-
-                    graph_store.add_edge(&edge)?;
+                    graph_store.add_edge(&node_id, &symbol_id, "DEFINES", "{}")?;
                     edges_added += 1;
                 }
             }
@@ -332,14 +323,7 @@ impl CodeAnalyzer {
                     self.project_id, callee_file.path, callee.name, callee.span.start_line
                 );
 
-                let edge = GraphEdge {
-                    from_id: caller_node_id,
-                    to_id: callee_node_id,
-                    kind: EdgeKind::Calls,
-                    properties: std::collections::HashMap::new(),
-                };
-
-                graph_store.add_edge(&edge)?;
+                graph_store.add_edge(&caller_node_id, &callee_node_id, "CALLS", "{}")?;
                 edges_added += 1;
             }
         }
@@ -350,17 +334,10 @@ impl CodeAnalyzer {
                 index.get_file_by_id(*from_file_id),
                 index.get_file_by_id(*to_file_id),
             ) {
-                let from_node_id = format!("file:{}", from_file.path);
-                let to_node_id = format!("file:{}", to_file.path);
+                let from_node_id = format!("file:{}:{}", self.project_id, from_file.path);
+                let to_node_id = format!("file:{}:{}", self.project_id, to_file.path);
 
-                let edge = GraphEdge {
-                    from_id: from_node_id,
-                    to_id: to_node_id,
-                    kind: EdgeKind::DependsOn,
-                    properties: std::collections::HashMap::new(),
-                };
-
-                graph_store.add_edge(&edge)?;
+                graph_store.add_edge(&from_node_id, &to_node_id, "DEPENDS_ON", "{}")?;
                 edges_added += 1;
             }
         }
@@ -379,7 +356,7 @@ impl CodeAnalyzer {
     ) -> Result<()> {
         let run = AnalysisRun {
             project_id: self.project_id.clone(),
-            commit_hash: None, // TODO: extract from git
+            commit_hash: self.current_commit_hash(),
             files_analyzed: index.files.len() as i32,
             symbols_extracted: symbols_extracted as i32,
             dependencies_found: dependencies_found as i32,
@@ -396,15 +373,85 @@ impl CodeAnalyzer {
         );
         Ok(())
     }
+
+    /// Return the repository's current Git commit, if it is a Git worktree.
+    fn current_commit_hash(&self) -> Option<String> {
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&self.repo_path)
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+
+        let commit = String::from_utf8(output.stdout).ok()?.trim().to_string();
+        (commit.len() == 40 || commit.len() == 64)
+            .then_some(commit)
+            .filter(|commit| commit.bytes().all(|byte| byte.is_ascii_hexdigit()))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::graph_builder::GraphBuilder;
+    use crate::store::DuckStore;
 
     #[test]
     fn test_analyzer_creation() {
         let analyzer = CodeAnalyzer::new("test-project", "/tmp/test");
         assert_eq!(analyzer.project_id, "test-project");
+    }
+
+    #[test]
+    fn test_commit_hash_handles_git_and_non_git_repositories() {
+        let outside_git = tempfile::tempdir().expect("non-git directory");
+        let non_git = CodeAnalyzer::new("non-git", outside_git.path());
+        assert_eq!(non_git.current_commit_hash(), None);
+
+        let repository_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let git = CodeAnalyzer::new("git", &repository_root);
+        let commit = git.current_commit_hash().expect("repository commit");
+        assert!(
+            commit.bytes().all(|byte| byte.is_ascii_hexdigit())
+                && (commit.len() == 40 || commit.len() == 64),
+            "unexpected commit: {commit}"
+        );
+    }
+
+    #[test]
+    fn test_analyze_persists_symbols_and_graph() {
+        let repository = tempfile::tempdir().expect("temporary repository");
+        std::fs::write(
+            repository.path().join("lib.rs"),
+            r#"
+                pub fn alpha() -> usize { 1 }
+                pub fn beta() -> usize { alpha() }
+            "#,
+        )
+        .expect("write Rust fixture");
+
+        let store = DuckStore::open_in_memory().expect("open DuckStore");
+        let graph = GraphBuilder::with_backend(&store);
+        let analyzer = CodeAnalyzer::new("graph-e2e", repository.path());
+        let result = analyzer
+            .analyze(&store, graph.backend())
+            .expect("analyze repository");
+
+        assert_eq!(result.files_analyzed, 1);
+        assert!(result.symbols_extracted >= 2, "result: {result:?}");
+        assert!(
+            graph.node_count() >= 3,
+            "file plus symbols should be persisted"
+        );
+        assert!(graph.edge_count() >= 2);
+        assert!(
+            store
+                .get_symbols_for_project("graph-e2e", 100)
+                .expect("read symbols")
+                .len()
+                >= 2
+        );
     }
 }

--- a/engine/src/config.rs
+++ b/engine/src/config.rs
@@ -22,8 +22,6 @@ pub struct AppConfig {
     #[serde(default)]
     pub retention: RetentionConfig,
     #[serde(default)]
-    pub cross_project: CrossProjectConfig,
-    #[serde(default)]
     pub watch: WatchConfig,
 }
 
@@ -54,19 +52,156 @@ impl AppConfig {
 
         let contents = fs::read_to_string(&path)
             .with_context(|| format!("failed to read {}", path.display()))?;
-        let config: Self = serde_yaml::from_str(&contents)
+        let config: Self = serde_norway::from_str(&contents)
             .with_context(|| format!("failed to parse {}", path.display()))?;
+        config
+            .validate()
+            .with_context(|| format!("invalid configuration in {}", path.display()))?;
         Ok(config)
     }
 
     /// Persist the current configuration to `~/.remembrant/config.yaml`.
     pub fn save(&self) -> Result<()> {
+        self.validate().context("refusing to save invalid config")?;
         let dir = Self::config_dir()?;
         fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
 
         let path = Self::config_path()?;
-        let yaml = serde_yaml::to_string(self).context("failed to serialize config")?;
+        let yaml = serde_norway::to_string(self).context("failed to serialize config")?;
         fs::write(&path, yaml).with_context(|| format!("failed to write {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Validate values that would otherwise panic or be silently ignored.
+    pub fn validate(&self) -> Result<()> {
+        if self.storage.duckdb_path.trim().is_empty() {
+            anyhow::bail!("storage.duckdb_path cannot be empty");
+        }
+        if self.storage.lancedb_path.trim().is_empty() {
+            anyhow::bail!("storage.lancedb_path cannot be empty");
+        }
+        if self.embedding.model.trim().is_empty() {
+            anyhow::bail!("embedding.model cannot be empty");
+        }
+        if self.embedding.endpoint.trim().is_empty() {
+            anyhow::bail!("embedding.endpoint cannot be empty");
+        }
+        if self.embedding.batch_size == 0 || self.embedding.batch_size > 10_000 {
+            anyhow::bail!("embedding.batch_size must be between 1 and 10000");
+        }
+        if self.embedding.dimensions == 0 || self.embedding.dimensions > 32_768 {
+            anyhow::bail!("embedding.dimensions must be between 1 and 32768");
+        }
+        if self.retention.raw_transcripts_days == 0 || self.retention.raw_transcripts_days > 100_000
+        {
+            anyhow::bail!("retention.raw_transcripts_days must be between 1 and 100000");
+        }
+        if self.watch.debounce_ms == 0 || self.watch.debounce_ms > 3_600_000 {
+            anyhow::bail!("watch.debounce_ms must be between 1 and 3600000");
+        }
+
+        let native_ids = ["claude_code", "codex", "gemini"];
+        for (name, entry) in [
+            ("claude_code", &self.agents.claude_code),
+            ("codex", &self.agents.codex),
+            ("gemini", &self.agents.gemini),
+        ] {
+            if entry.path.trim().is_empty() {
+                anyhow::bail!("agents.{name}.path cannot be empty");
+            }
+        }
+
+        let mut dynamic_ids = std::collections::HashSet::new();
+        for agent in &self.agents.dynamic {
+            if agent.id.trim().is_empty() {
+                anyhow::bail!("dynamic agent id cannot be empty");
+            }
+            if agent.id.len() > 80
+                || !agent.id.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
+                })
+            {
+                anyhow::bail!(
+                    "dynamic agent id '{}' may contain only ASCII letters, digits, '_', '-', or '.'",
+                    agent.id
+                );
+            }
+            if native_ids.contains(&agent.id.as_str()) || !dynamic_ids.insert(agent.id.clone()) {
+                anyhow::bail!("duplicate or reserved dynamic agent id '{}'", agent.id);
+            }
+            if agent.display_name.trim().is_empty() {
+                anyhow::bail!("dynamic agent '{}' display_name cannot be empty", agent.id);
+            }
+            if agent.path.trim().is_empty() {
+                anyhow::bail!("dynamic agent '{}' path cannot be empty", agent.id);
+            }
+            if !matches!(agent.adapter_type.as_str(), "sqlite" | "jsonl") {
+                anyhow::bail!(
+                    "dynamic agent '{}' has unsupported adapter type '{}'",
+                    agent.id,
+                    agent.adapter_type
+                );
+            }
+            if agent.adapter_type == "sqlite"
+                && let Some(mapping) = &agent.sqlite
+            {
+                let db_path = std::path::Path::new(&mapping.db_file);
+                if db_path.is_absolute()
+                    || db_path
+                        .components()
+                        .any(|component| matches!(component, std::path::Component::ParentDir))
+                {
+                    anyhow::bail!(
+                        "dynamic agent '{}' sqlite.db_file must be a relative path without '..'",
+                        agent.id
+                    );
+                }
+                validate_sqlite_identifier(&mapping.sessions_table, "sessions table")?;
+                validate_sqlite_identifier(&mapping.session_columns.id, "session ID column")?;
+                if !matches!(
+                    mapping.session_columns.timestamp_format.as_str(),
+                    "iso8601" | "unix_seconds" | "unix_millis"
+                ) {
+                    anyhow::bail!(
+                        "dynamic agent '{}' has unsupported SQLite timestamp format '{}'",
+                        agent.id,
+                        mapping.session_columns.timestamp_format
+                    );
+                }
+                for column in [
+                    mapping.session_columns.project_id.as_deref(),
+                    mapping.session_columns.started_at.as_deref(),
+                    mapping.session_columns.ended_at.as_deref(),
+                    mapping.session_columns.message_count.as_deref(),
+                    mapping.session_columns.summary.as_deref(),
+                    mapping.session_columns.content.as_deref(),
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    validate_sqlite_identifier(column, "session column")?;
+                }
+                if let Some(table) = mapping.tool_calls_table.as_deref() {
+                    validate_sqlite_identifier(table, "tool-call table")?;
+                }
+                if let Some(columns) = &mapping.tool_call_columns {
+                    validate_sqlite_identifier(&columns.id, "tool-call ID column")?;
+                    for column in [
+                        columns.session_id.as_deref(),
+                        columns.tool_name.as_deref(),
+                        columns.command.as_deref(),
+                        columns.success.as_deref(),
+                        columns.timestamp.as_deref(),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    {
+                        validate_sqlite_identifier(column, "tool-call column")?;
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 }
@@ -123,19 +258,15 @@ impl AgentEntry {
 /// Paths for persistent stores.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageConfig {
-    pub base_dir: String,
     pub duckdb_path: String,
     pub lancedb_path: String,
-    pub graph_db_path: String,
 }
 
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
-            base_dir: "~/.remembrant".to_string(),
             duckdb_path: "~/.remembrant/remembrant.duckdb".to_string(),
             lancedb_path: "~/.remembrant/lancedb".to_string(),
-            graph_db_path: "~/.remembrant/graph".to_string(),
         }
     }
 }
@@ -148,7 +279,8 @@ impl Default for StorageConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingConfig {
     pub model: String,
-    pub api_key_env: String,
+    #[serde(default = "default_embedding_endpoint")]
+    pub endpoint: String,
     pub batch_size: usize,
     pub dimensions: usize,
 }
@@ -157,11 +289,26 @@ impl Default for EmbeddingConfig {
     fn default() -> Self {
         Self {
             model: "text-embedding-nomic-embed-text-v1.5@q8_0".to_string(),
-            api_key_env: String::new(),
+            endpoint: "http://localhost:1234/v1".to_string(),
             batch_size: 100,
             dimensions: 768,
         }
     }
+}
+
+fn default_embedding_endpoint() -> String {
+    "http://localhost:1234/v1".to_string()
+}
+
+fn validate_sqlite_identifier(value: &str, field: &str) -> Result<()> {
+    if value.is_empty()
+        || !value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '_')
+    {
+        anyhow::bail!("SQLite {field} identifiers may contain only ASCII letters, digits, or '_'");
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -188,7 +335,6 @@ pub struct DistillationConfig {
     pub level: DistillationLevel,
     pub llm_provider: String,
     pub llm_model: String,
-    pub api_key_env: String,
 }
 
 impl Default for DistillationConfig {
@@ -197,7 +343,6 @@ impl Default for DistillationConfig {
             level: DistillationLevel::default(),
             llm_provider: "http://localhost:1234/v1".to_string(),
             llm_model: "qwen/qwen3-30b-a3b".to_string(),
-            api_key_env: String::new(),
         }
     }
 }
@@ -221,37 +366,6 @@ impl Default for RetentionConfig {
 }
 
 // ---------------------------------------------------------------------------
-// Cross-project
-// ---------------------------------------------------------------------------
-
-/// Default visibility for cross-project memory items.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-#[derive(Default)]
-pub enum Visibility {
-    #[default]
-    Public,
-    Private,
-}
-
-/// Cross-project sharing settings.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CrossProjectConfig {
-    pub enabled: bool,
-    #[serde(default)]
-    pub default_visibility: Visibility,
-}
-
-impl Default for CrossProjectConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            default_visibility: Visibility::default(),
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Watch
 // ---------------------------------------------------------------------------
 
@@ -259,15 +373,11 @@ impl Default for CrossProjectConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WatchConfig {
     pub debounce_ms: u64,
-    pub auto_start: bool,
 }
 
 impl Default for WatchConfig {
     fn default() -> Self {
-        Self {
-            debounce_ms: 5000,
-            auto_start: false,
-        }
+        Self { debounce_ms: 5000 }
     }
 }
 
@@ -282,21 +392,19 @@ mod tests {
     #[test]
     fn default_config_round_trips_through_yaml() {
         let config = AppConfig::default();
-        let yaml = serde_yaml::to_string(&config).expect("serialize");
-        let parsed: AppConfig = serde_yaml::from_str(&yaml).expect("deserialize");
+        let yaml = serde_norway::to_string(&config).expect("serialize");
+        let parsed: AppConfig = serde_norway::from_str(&yaml).expect("deserialize");
 
         assert_eq!(
             parsed.embedding.model,
             "text-embedding-nomic-embed-text-v1.5@q8_0"
         );
+        assert_eq!(parsed.embedding.endpoint, "http://localhost:1234/v1");
         assert_eq!(parsed.embedding.batch_size, 100);
         assert_eq!(parsed.embedding.dimensions, 768);
         assert_eq!(parsed.distillation.level, DistillationLevel::Balanced);
         assert_eq!(parsed.retention.raw_transcripts_days, 30);
-        assert!(parsed.cross_project.enabled);
-        assert_eq!(parsed.cross_project.default_visibility, Visibility::Public);
         assert_eq!(parsed.watch.debounce_ms, 5000);
-        assert!(!parsed.watch.auto_start);
         assert!(parsed.agents.claude_code.enabled);
         assert_eq!(parsed.agents.claude_code.path, "~/.claude");
     }
@@ -304,13 +412,54 @@ mod tests {
     #[test]
     fn partial_yaml_fills_defaults() {
         let yaml = "retention:\n  raw_transcripts_days: 90\n";
-        let config: AppConfig = serde_yaml::from_str(yaml).expect("deserialize");
+        let config: AppConfig = serde_norway::from_str(yaml).expect("deserialize");
 
         // Overridden field
         assert_eq!(config.retention.raw_transcripts_days, 90);
         // Everything else should be default
         assert_eq!(config.embedding.dimensions, 768);
+        assert_eq!(config.embedding.endpoint, "http://localhost:1234/v1");
         assert_eq!(config.distillation.level, DistillationLevel::Balanced);
+    }
+
+    #[test]
+    fn legacy_unknown_config_keys_are_ignored() {
+        let yaml =
+            "watch:\n  debounce_ms: 250\n  auto_start: true\ncross_project:\n  enabled: false\n";
+        let config: AppConfig = serde_norway::from_str(yaml).expect("deserialize");
+        assert_eq!(config.watch.debounce_ms, 250);
+    }
+
+    #[test]
+    fn invalid_values_are_rejected() {
+        let mut config = AppConfig::default();
+        config.embedding.dimensions = 0;
+        assert!(config.validate().is_err());
+
+        config = AppConfig::default();
+        config.agents.dynamic = vec![crate::ingest::DynamicAgentConfig {
+            id: "bad agent".into(),
+            display_name: "Bad".into(),
+            enabled: false,
+            path: "/tmp/bad".into(),
+            adapter_type: "jsonl".into(),
+            sqlite: None,
+            jsonl: None,
+        }];
+        assert!(config.validate().is_err());
+
+        config = AppConfig::default();
+        config.agents.dynamic = vec![crate::ingest::DynamicAgentConfig {
+            id: "claude_code".into(),
+            display_name: "Reserved".into(),
+            enabled: false,
+            path: "/tmp/reserved".into(),
+            adapter_type: "jsonl".into(),
+            sqlite: None,
+            jsonl: None,
+        }];
+        let error = config.validate().unwrap_err();
+        assert!(error.to_string().contains("duplicate or reserved"));
     }
 
     #[test]

--- a/engine/src/detect.rs
+++ b/engine/src/detect.rs
@@ -32,20 +32,27 @@ pub fn detect_agents() -> AgentDetection {
         return AgentDetection::default();
     };
 
+    detect_agents_from(&home)
+}
+
+/// Scan for known agents beneath an explicit home-like root.
+///
+/// Tests use this form so verification never traverses the developer's real
+/// agent transcript directories.
+pub fn detect_agents_from(home: &Path) -> AgentDetection {
     AgentDetection {
-        claude_code: detect_claude_code(&home),
-        codex: detect_codex(&home),
-        gemini: detect_gemini(&home),
+        claude_code: detect_claude_code(home),
+        codex: detect_codex(home),
+        gemini: detect_gemini(home),
     }
 }
 
 /// Resolve the user's home directory.
 fn home_dir() -> Option<PathBuf> {
-    // Prefer $HOME; fall back to std::env::home_dir (deprecated but still useful).
-    std::env::var_os("HOME").map(PathBuf::from).or_else(|| {
-        #[allow(deprecated)]
-        std::env::home_dir()
-    })
+    // Prefer $HOME; fall back to the platform home-directory resolver.
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(dirs::home_dir)
 }
 
 // ---------------------------------------------------------------------------
@@ -181,14 +188,7 @@ fn count_dirs(dir: &PathBuf) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn detect_agents_returns_without_panic() {
-        // Smoke test: must not panic regardless of what's on disk.
-        let detection = detect_agents();
-        // At minimum the struct should be constructable.
-        let _ = format!("{detection:?}");
-    }
+    use std::fs;
 
     #[test]
     fn default_detection_is_all_none() {
@@ -196,5 +196,29 @@ mod tests {
         assert!(d.claude_code.is_none());
         assert!(d.codex.is_none());
         assert!(d.gemini.is_none());
+    }
+
+    #[test]
+    fn detect_agents_from_uses_isolated_root() {
+        let home = tempfile::tempdir().expect("temporary home");
+        fs::create_dir_all(home.path().join(".claude/projects/project-a")).unwrap();
+        fs::create_dir_all(home.path().join(".codex/sessions/session-a")).unwrap();
+        fs::write(home.path().join(".codex/config.toml"), "").unwrap();
+        fs::create_dir_all(home.path().join(".gemini/tmp/project/chats")).unwrap();
+        fs::write(
+            home.path().join(".gemini/tmp/project/chats/session.json"),
+            "{}",
+        )
+        .unwrap();
+        fs::write(home.path().join(".gemini/projects.json"), "{}").unwrap();
+
+        let detection = detect_agents_from(home.path());
+        assert_eq!(detection.claude_code.expect("claude").session_count, 1);
+        let codex = detection.codex.expect("codex");
+        assert_eq!(codex.session_count, 1);
+        assert!(codex.config_found);
+        let gemini = detection.gemini.expect("gemini");
+        assert_eq!(gemini.session_count, 1);
+        assert!(gemini.config_found);
     }
 }

--- a/engine/src/distill.rs
+++ b/engine/src/distill.rs
@@ -17,6 +17,9 @@ use crate::store::duckdb::{Decision, Fact, Memory, Session};
 ///
 /// Works out-of-the-box with LM Studio (localhost:1234) and can be pointed
 /// at any compatible endpoint (OpenAI, Ollama, vLLM, etc.).
+const LLM_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const LLM_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 pub struct LlmClient {
     base_url: String,
     model: String,
@@ -63,7 +66,11 @@ impl LlmClient {
         Self {
             base_url: base_url.trim_end_matches('/').to_string(),
             model: model.to_string(),
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .connect_timeout(LLM_CONNECT_TIMEOUT)
+                .timeout(LLM_REQUEST_TIMEOUT)
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
         }
     }
 
@@ -347,12 +354,8 @@ impl Distiller {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("no LLM client configured"))?;
 
-        // Truncate for local models (max ~4000 chars).
-        let truncated = if text.len() > 4000 {
-            &text[..4000]
-        } else {
-            text
-        };
+        // Truncate for local models (max 4000 Unicode scalar values).
+        let truncated: String = text.chars().take(4000).collect();
 
         let system_prompt = "You are a knowledge extraction assistant. Analyze coding agent \
              transcripts and extract structured knowledge. Respond ONLY with valid JSON.";
@@ -387,7 +390,7 @@ impl Distiller {
         let extraction: LlmExtraction = serde_json::from_str(json_str).with_context(|| {
             format!(
                 "failed to parse LLM JSON response: {}",
-                &raw[..raw.len().min(200)]
+                raw.chars().take(200).collect::<String>()
             )
         })?;
 
@@ -867,15 +870,28 @@ fn looks_like_tool_output(line: &str) -> bool {
 /// Truncate a string at the first sentence boundary or at `max_len`.
 fn truncate_at_sentence(text: &str, max_len: usize) -> String {
     let text = text.trim();
-    if text.len() <= max_len {
+    if text.chars().count() <= max_len {
         return text.to_string();
     }
-    // Find the first sentence-ending punctuation within max_len.
-    if let Some(pos) = text[..max_len].rfind(['.', '!', '?']) {
-        text[..=pos].to_string()
-    } else {
-        format!("{}...", &text[..max_len.saturating_sub(3)])
+
+    let prefix: String = text.chars().take(max_len).collect();
+    // Find the last sentence-ending punctuation within the prefix.
+    let sentence = prefix
+        .char_indices()
+        .rev()
+        .find(|(_, character)| matches!(character, '.' | '!' | '?'))
+        .map(|(pos, character)| &prefix[..pos + character.len_utf8()]);
+    if let Some(sentence) = sentence {
+        return sentence.to_string();
     }
+
+    let keep = max_len.saturating_sub(3);
+    if keep == 0 {
+        return "...".to_string();
+    }
+
+    let truncated: String = prefix.chars().take(keep).collect();
+    format!("{truncated}...")
 }
 
 // ---------------------------------------------------------------------------
@@ -1002,7 +1018,6 @@ mod tests {
             level: DistillationLevel::None,
             llm_provider: String::new(),
             llm_model: String::new(),
-            api_key_env: String::new(),
         };
         let distiller = Distiller::new(&config);
         let session = make_session("s-none");
@@ -1123,6 +1138,19 @@ mod tests {
 
         let with_plain_fences = "```\n{\"key\": \"value\"}\n```";
         assert_eq!(strip_code_fences(with_plain_fences), "{\"key\": \"value\"}");
+    }
+
+    #[test]
+    fn test_truncate_at_sentence_is_unicode_safe() {
+        let text = "🔐".repeat(300);
+        let truncated = truncate_at_sentence(&text, 200);
+        assert_eq!(truncated.chars().count(), 200);
+        assert!(truncated.ends_with("..."));
+
+        assert_eq!(
+            truncate_at_sentence("Unicode boundary. More text", 18),
+            "Unicode boundary."
+        );
     }
 
     #[test]

--- a/engine/src/embed_pipeline.rs
+++ b/engine/src/embed_pipeline.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
 use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
-use uuid::Uuid;
 
 use crate::embedding::EmbedProvider;
 use crate::store::duckdb::{Memory, Session, ToolCall};
@@ -51,12 +51,35 @@ impl fmt::Display for Granularity {
 #[derive(Debug, Clone)]
 pub struct EmbedChunk {
     pub id: String,
+    pub source_id: Option<String>,
     pub content: String,
     pub granularity: Granularity,
     pub project_id: Option<String>,
     pub session_id: Option<String>,
     pub file_path: Option<String>,
     pub language: Option<String>,
+}
+
+/// Build a deterministic embedding ID from the chunk's source and content.
+fn stable_embedding_id(chunk: &EmbedChunk) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(chunk.granularity.to_string().as_bytes());
+    hasher.update([0]);
+    hasher.update(chunk.source_id.as_deref().unwrap_or("").as_bytes());
+    hasher.update([0]);
+    hasher.update(chunk.session_id.as_deref().unwrap_or("").as_bytes());
+    hasher.update([0]);
+    hasher.update(chunk.file_path.as_deref().unwrap_or("").as_bytes());
+    hasher.update([0]);
+    hasher.update(chunk.content.as_bytes());
+    let digest = hasher.finalize();
+    format!(
+        "embed-{}",
+        digest
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -136,15 +159,18 @@ impl EmbedPipeline {
             );
 
             if !content.trim().is_empty() {
-                chunks.push(EmbedChunk {
-                    id: Uuid::new_v4().to_string(),
+                let mut chunk = EmbedChunk {
+                    id: String::new(),
+                    source_id: Some(session.id.clone()),
                     content,
                     granularity: Granularity::Session,
                     project_id: session.project_id.clone(),
                     session_id: Some(session.id.clone()),
                     file_path: None,
                     language: None,
-                });
+                };
+                chunk.id = stable_embedding_id(&chunk);
+                chunks.push(chunk);
             }
 
             // One CodeChange chunk per changed file
@@ -153,15 +179,18 @@ impl EmbedPipeline {
                     "File changed: {file}\nSession: {summary}\nAgent: {agent}",
                     agent = session.agent,
                 );
-                chunks.push(EmbedChunk {
-                    id: Uuid::new_v4().to_string(),
+                let mut chunk = EmbedChunk {
+                    id: String::new(),
+                    source_id: Some(format!("{}\u{0}{file}", session.id)),
                     content,
                     granularity: Granularity::CodeChange,
                     project_id: session.project_id.clone(),
                     session_id: Some(session.id.clone()),
                     file_path: Some(file.clone()),
                     language: None,
-                });
+                };
+                chunk.id = stable_embedding_id(&chunk);
+                chunks.push(chunk);
             }
         }
 
@@ -176,15 +205,18 @@ impl EmbedPipeline {
             .map(|m| {
                 let mem_type = m.memory_type.as_deref().unwrap_or("general");
                 let content = format!("[{mem_type}] {}", m.content);
-                EmbedChunk {
-                    id: Uuid::new_v4().to_string(),
+                let mut chunk = EmbedChunk {
+                    id: String::new(),
+                    source_id: Some(m.id.clone()),
                     content,
                     granularity: Granularity::Memory,
                     project_id: m.project_id.clone(),
                     session_id: m.source_session_id.clone(),
                     file_path: None,
                     language: None,
-                }
+                };
+                chunk.id = stable_embedding_id(&chunk);
+                chunk
             })
             .collect()
     }
@@ -198,15 +230,18 @@ impl EmbedPipeline {
                 let tool_name = tc.tool_name.as_deref().unwrap_or("unknown");
                 let command = tc.command.as_deref().unwrap_or("");
                 let content = format!("Tool: {tool_name}\nCommand: {command}");
-                EmbedChunk {
-                    id: Uuid::new_v4().to_string(),
+                let mut chunk = EmbedChunk {
+                    id: String::new(),
+                    source_id: Some(tc.id.clone()),
                     content,
                     granularity: Granularity::ToolCall,
                     project_id: None,
                     session_id: tc.session_id.clone(),
                     file_path: None,
                     language: None,
-                }
+                };
+                chunk.id = stable_embedding_id(&chunk);
+                chunk
             })
             .collect()
     }
@@ -404,6 +439,12 @@ mod tests {
         ];
 
         let chunks = EmbedPipeline::extract_session_chunks(&sessions);
+        let rerun = EmbedPipeline::extract_session_chunks(&sessions);
+        assert_eq!(
+            chunks.iter().map(|chunk| &chunk.id).collect::<Vec<_>>(),
+            rerun.iter().map(|chunk| &chunk.id).collect::<Vec<_>>()
+        );
+        assert!(chunks.iter().all(|chunk| chunk.id.starts_with("embed-")));
 
         // s-1: 1 session chunk + 2 code-change chunks = 3
         // s-2: 1 session chunk + 1 code-change chunk  = 2
@@ -446,6 +487,11 @@ mod tests {
         ];
 
         let chunks = EmbedPipeline::extract_memory_chunks(&memories);
+        let rerun = EmbedPipeline::extract_memory_chunks(&memories);
+        assert_eq!(
+            chunks.iter().map(|chunk| &chunk.id).collect::<Vec<_>>(),
+            rerun.iter().map(|chunk| &chunk.id).collect::<Vec<_>>()
+        );
 
         assert_eq!(chunks.len(), 2); // empty one skipped
         assert!(chunks[0].content.starts_with("[insight]"));
@@ -462,6 +508,11 @@ mod tests {
         ];
 
         let chunks = EmbedPipeline::extract_tool_call_chunks(&tool_calls);
+        let rerun = EmbedPipeline::extract_tool_call_chunks(&tool_calls);
+        assert_eq!(
+            chunks.iter().map(|chunk| &chunk.id).collect::<Vec<_>>(),
+            rerun.iter().map(|chunk| &chunk.id).collect::<Vec<_>>()
+        );
         assert_eq!(chunks.len(), 2);
         assert!(chunks[0].content.contains("Tool: bash"));
         assert!(chunks[0].content.contains("Command: cargo build"));
@@ -501,6 +552,31 @@ mod tests {
         assert_eq!(stats.chunks_embedded, 4);
         assert_eq!(stats.chunks_stored, 4);
         assert_eq!(stats.errors, 0);
+
+        let rerun = pipeline
+            .run(&sessions, &memories, &tool_calls, &embedder)
+            .await
+            .expect("pipeline rerun");
+        assert_eq!(rerun.chunks_stored, 4);
+        let query = vec![0.0; dim as usize];
+        assert_eq!(
+            pipeline
+                .lance_store
+                .search_code(&query, 10)
+                .await
+                .expect("search code embeddings")
+                .len(),
+            3
+        );
+        assert_eq!(
+            pipeline
+                .lance_store
+                .search_memories(&query, 10)
+                .await
+                .expect("search memory embeddings")
+                .len(),
+            1
+        );
     }
 
     #[test]

--- a/engine/src/embedding.rs
+++ b/engine/src/embedding.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info, warn};
+use std::time::Duration;
+use tracing::{debug, info};
 
 // ---------------------------------------------------------------------------
 // Provider trait
@@ -68,13 +69,17 @@ impl LmStudioEmbedder {
             base_url: base_url.trim_end_matches('/').to_string(),
             model: model.to_string(),
             dimensions,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(5))
+                .timeout(Duration::from_secs(120))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
         }
     }
 
     /// Build an embedder from the application's [`EmbeddingConfig`](crate::config::EmbeddingConfig).
     pub fn from_config(config: &crate::config::EmbeddingConfig) -> Self {
-        Self::new(&config.model, config.dimensions)
+        Self::with_base_url(&config.endpoint, &config.model, config.dimensions)
     }
 }
 
@@ -134,10 +139,16 @@ impl EmbedProvider for LmStudioEmbedder {
             .collect();
 
         if vectors.len() != texts.len() {
-            warn!(
-                expected = texts.len(),
-                got = vectors.len(),
-                "LM Studio returned a different number of embeddings than requested"
+            anyhow::bail!(
+                "LM Studio returned {} embeddings for {} inputs",
+                vectors.len(),
+                texts.len()
+            );
+        }
+        if vectors.iter().any(|vector| vector.len() != self.dimensions) {
+            anyhow::bail!(
+                "LM Studio returned an embedding with dimensions other than {}",
+                self.dimensions
             );
         }
 
@@ -266,13 +277,13 @@ mod tests {
     fn test_from_config() {
         let config = crate::config::EmbeddingConfig {
             model: "test-model".to_string(),
-            api_key_env: String::new(),
+            endpoint: "http://127.0.0.1:9999/v1/".to_string(),
             batch_size: 50,
             dimensions: 384,
         };
         let embedder = LmStudioEmbedder::from_config(&config);
         assert_eq!(embedder.model_name(), "test-model");
         assert_eq!(embedder.dimensions(), 384);
-        assert_eq!(embedder.base_url, "http://localhost:1234/v1");
+        assert_eq!(embedder.base_url, "http://127.0.0.1:9999/v1");
     }
 }

--- a/engine/src/graph_builder.rs
+++ b/engine/src/graph_builder.rs
@@ -34,6 +34,8 @@ pub trait GraphBackend {
     fn get_node(&self, id: &str) -> Result<Option<(String, String, String, String)>>; // (id, kind, name, props)
     fn delete_node(&self, id: &str) -> Result<bool>;
     fn query_neighbors(&self, id: &str, edge_kind: Option<&str>) -> Result<Vec<NeighborInfo>>;
+    /// Return all graph nodes as `(id, kind, name, JSON properties)`.
+    fn all_nodes(&self) -> Result<Vec<(String, String, String, String)>>;
     fn node_count(&self) -> Result<usize>;
     fn edge_count(&self) -> Result<usize>;
 }
@@ -141,6 +143,20 @@ impl GraphBackend for GraphStore {
             .collect())
     }
 
+    fn all_nodes(&self) -> Result<Vec<(String, String, String, String)>> {
+        Ok(GraphStore::all_nodes(self)?
+            .into_iter()
+            .map(|node| {
+                (
+                    node.id,
+                    node.kind.table_name().to_string(),
+                    node.name,
+                    props_to_json(&node.properties),
+                )
+            })
+            .collect())
+    }
+
     fn node_count(&self) -> Result<usize> {
         GraphStoreBackend::node_count(self)
     }
@@ -187,6 +203,14 @@ impl GraphBackend for DuckStore {
             .collect())
     }
 
+    fn all_nodes(&self) -> Result<Vec<(String, String, String, String)>> {
+        Ok(self
+            .list_graph_nodes()?
+            .into_iter()
+            .map(|node| (node.id, node.kind, node.name, node.properties))
+            .collect())
+    }
+
     fn node_count(&self) -> Result<usize> {
         self.count_graph_nodes()
     }
@@ -224,6 +248,15 @@ impl GraphBackend for &DuckStore {
             })
             .collect())
     }
+
+    fn all_nodes(&self) -> Result<Vec<(String, String, String, String)>> {
+        Ok((*self)
+            .list_graph_nodes()?
+            .into_iter()
+            .map(|node| (node.id, node.kind, node.name, node.properties))
+            .collect())
+    }
+
     fn node_count(&self) -> Result<usize> {
         (*self).count_graph_nodes()
     }

--- a/engine/src/hybrid_search.rs
+++ b/engine/src/hybrid_search.rs
@@ -10,10 +10,10 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
 use crate::embedding::EmbedProvider;
+use crate::graph_builder::GraphBackend;
 use crate::semantic_scorer::keyword_scorer;
 use crate::semantic_tree::TreeBuilder;
 use crate::store::duckdb::DuckStore;
-use crate::store::graph::{GraphStore, GraphStoreBackend};
 use crate::store::lance::LanceStore;
 use crate::xpath_query;
 
@@ -283,7 +283,7 @@ impl<'a> HybridSearch<'a> {
         query: &str,
         limit: usize,
         lance: Option<&LanceStore>,
-        graph: Option<&GraphStore>,
+        graph: Option<&dyn GraphBackend>,
         embedder: Option<&P>,
     ) -> Result<Vec<HybridResult>> {
         let mut ranked_lists: Vec<(Vec<RankedResult>, f64)> = Vec::new();
@@ -443,7 +443,7 @@ impl<'a> HybridSearch<'a> {
         query: &str,
         limit: usize,
         lance: Option<&LanceStore>,
-        graph: Option<&GraphStore>,
+        graph: Option<&dyn GraphBackend>,
         embedder: Option<&P>,
     ) -> Result<(Vec<HybridResult>, QueryComplexity)> {
         let complexity = classify_query(query);
@@ -472,7 +472,7 @@ impl<'a> HybridSearch<'a> {
         query: &str,
         limit: usize,
         lance: Option<&LanceStore>,
-        graph: Option<&GraphStore>,
+        graph: Option<&dyn GraphBackend>,
         embedder: Option<&P>,
     ) -> Result<Vec<HybridResult>> {
         let trimmed = query.trim();
@@ -811,7 +811,11 @@ impl<'a> HybridSearch<'a> {
     // Internal: graph proximity search (returns ranked list for RRF)
     // -----------------------------------------------------------------------
 
-    fn search_graph_ranked(&self, query: &str, graph: &GraphStore) -> Result<Vec<RankedResult>> {
+    fn search_graph_ranked(
+        &self,
+        query: &str,
+        graph: &dyn GraphBackend,
+    ) -> Result<Vec<RankedResult>> {
         let mut results: Vec<RankedResult> = Vec::new();
         let query_lower = query.to_lowercase();
         let query_words: Vec<&str> = query_lower.split_whitespace().collect();
@@ -819,8 +823,8 @@ impl<'a> HybridSearch<'a> {
         // Find graph nodes whose names match query words
         // Then include their neighbors as related results
         if let Ok(all_nodes) = graph.all_nodes() {
-            for node in &all_nodes {
-                let name_lower = node.name.to_lowercase();
+            for (node_id, node_kind, node_name, _properties) in &all_nodes {
+                let name_lower = node_name.to_lowercase();
                 let word_matches = query_words
                     .iter()
                     .filter(|w| name_lower.contains(*w))
@@ -833,13 +837,11 @@ impl<'a> HybridSearch<'a> {
                 let match_score = word_matches as f64 / query_words.len().max(1) as f64;
 
                 results.push(RankedResult {
-                    id: node.id.clone(),
-                    content: node.name.clone(),
-                    result_type: match node.kind {
-                        crate::store::graph::NodeKind::Memory => ResultType::Memory,
-                        crate::store::graph::NodeKind::CodeEntity
-                        | crate::store::graph::NodeKind::Symbol
-                        | crate::store::graph::NodeKind::Module => ResultType::CodeEntity,
+                    id: node_id.clone(),
+                    content: node_name.clone(),
+                    result_type: match node_kind.as_str() {
+                        "Memory" => ResultType::Memory,
+                        "CodeEntity" | "Symbol" | "Module" => ResultType::CodeEntity,
                         _ => ResultType::Session,
                     },
                     raw_score: match_score,
@@ -848,18 +850,18 @@ impl<'a> HybridSearch<'a> {
                 });
 
                 // Also add neighbors with decayed score
-                if let Ok(neighbors) = graph.query_neighbors(&node.id, None) {
+                if let Ok(neighbors) = graph.query_neighbors(node_id, None) {
                     for n in neighbors.iter().take(5) {
                         results.push(RankedResult {
-                            id: n.node.id.clone(),
-                            content: n.node.name.clone(),
+                            id: n.id.clone(),
+                            content: n.name.clone(),
                             result_type: ResultType::Session,
                             raw_score: match_score * 0.5, // Neighbors get half the score
                             sources: vec!["graph_neighbor".to_string()],
                             metadata: {
                                 let mut m = HashMap::new();
-                                m.insert("edge_kind".to_string(), n.edge_kind.name().to_string());
-                                m.insert("via".to_string(), node.id.clone());
+                                m.insert("edge_kind".to_string(), n.edge_kind.clone());
+                                m.insert("via".to_string(), node_id.clone());
                                 m
                             },
                         });
@@ -964,6 +966,10 @@ fn parse_node_type_and_id(node_id: &str, node_type: &str) -> (ResultType, String
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::embedding::MockEmbedder;
+    use crate::store::graph::{
+        EdgeKind, GraphEdge, GraphNode, GraphStore, GraphStoreBackend, NodeKind,
+    };
 
     #[test]
     fn test_text_only_search() {
@@ -1050,6 +1056,43 @@ mod tests {
         assert!(!results.is_empty());
         // RRF score = weight / (k + rank) = 0.9 / (60 + 1) ≈ 0.0147 for rank 0
         assert!(results[0].score > 0.0, "RRF score should be positive");
+    }
+
+    #[tokio::test]
+    async fn test_graph_layer_accepts_any_backend() {
+        let store = DuckStore::open_in_memory().unwrap();
+        let graph = GraphStore::new();
+        GraphStoreBackend::add_node(
+            &graph,
+            &GraphNode {
+                id: "memory:m-1".into(),
+                kind: NodeKind::Memory,
+                name: "authentication uses JWT".into(),
+                properties: Default::default(),
+            },
+        )
+        .unwrap();
+        GraphStoreBackend::add_edge(
+            &graph,
+            &GraphEdge {
+                from_id: "memory:m-1".into(),
+                to_id: "session:s-1".into(),
+                kind: EdgeKind::DerivedFrom,
+                properties: Default::default(),
+            },
+        )
+        .unwrap();
+        // The session endpoint does not need to exist for this traversal test;
+        // only the matching Memory node is required.
+
+        let search = HybridSearch::new(&store);
+        let results = search
+            .search::<MockEmbedder>("authentication", 10, None, Some(&graph), None)
+            .await
+            .unwrap();
+        assert!(results.iter().any(
+            |result| result.id == "memory:m-1" && result.sources.contains(&"graph".to_string())
+        ));
     }
 
     #[test]

--- a/engine/src/ingest/adapter.rs
+++ b/engine/src/ingest/adapter.rs
@@ -211,7 +211,7 @@ pub struct DynamicAgentConfig {
     pub enabled: bool,
     /// Base path to the agent's data directory (supports `~`).
     pub path: String,
-    /// Adapter type: "sqlite", "jsonl", "json", "markdown".
+    /// Adapter type: `"sqlite"` or `"jsonl"`; unsupported values are rejected.
     pub adapter_type: String,
     /// For SQLite adapters: table/column mappings.
     #[serde(default)]
@@ -488,7 +488,7 @@ sqlite:
     content: messages
     timestamp_format: iso8601
 "#;
-        let config: DynamicAgentConfig = serde_yaml::from_str(yaml).unwrap();
+        let config: DynamicAgentConfig = serde_norway::from_str(yaml).unwrap();
         assert_eq!(config.id, "goose");
         assert!(config.enabled);
         assert!(config.sqlite.is_some());

--- a/engine/src/ingest/codex.rs
+++ b/engine/src/ingest/codex.rs
@@ -126,10 +126,9 @@ impl CodexIngester {
     /// Returns `None` if the home directory cannot be resolved or `~/.codex`
     /// does not exist.
     pub fn new() -> Option<Self> {
-        let home = std::env::var_os("HOME").map(PathBuf::from).or_else(|| {
-            #[allow(deprecated)]
-            std::env::home_dir()
-        })?;
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .or_else(dirs::home_dir)?;
         let base = home.join(".codex");
         if base.is_dir() {
             Some(Self { base_path: base })
@@ -681,7 +680,7 @@ mod tests {
     }
 
     fn sample_session_jsonl() -> String {
-        let lines = vec![
+        let lines = [
             r#"{"timestamp":"2026-03-05T05:00:04.837Z","type":"session_meta","payload":{"id":"019cbc5e-test-id","timestamp":"2026-03-05T05:00:04.618Z","cwd":"/home/user/myproject","originator":"codex_exec","cli_version":"0.107.0","source":"exec","model_provider":"openai","git":{"commit_hash":"abc123","branch":"main","repository_url":"https://github.com/alice/myrepo.git"}}}"#,
             r#"{"timestamp":"2026-03-05T05:00:05.000Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"Fix the bug"}]}}"#,
             r#"{"timestamp":"2026-03-05T05:00:06.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I will fix it."}]}}"#,

--- a/engine/src/ingest/gemini.rs
+++ b/engine/src/ingest/gemini.rs
@@ -376,8 +376,9 @@ impl GeminiIngester {
                 .and_then(|m| m.content.first_text())
                 .map(|t| {
                     let trimmed = t.trim();
-                    if trimmed.len() > 200 {
-                        format!("{}...", &trimmed[..200])
+                    if trimmed.chars().count() > 200 {
+                        let truncated: String = trimmed.chars().take(197).collect();
+                        format!("{truncated}...")
                     } else {
                         trimmed.to_string()
                     }

--- a/engine/src/ingest/jsonl_adapter.rs
+++ b/engine/src/ingest/jsonl_adapter.rs
@@ -1,0 +1,463 @@
+//! Configuration-driven adapter for newline-delimited JSON agent artifacts.
+//!
+//! Unlike the native adapters, this parser makes no assumptions about field
+//! names. A YAML mapping describes where session IDs, timestamps, message
+//! content, and tool calls live in each line.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use glob::Pattern;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use super::adapter::{AgentAdapter, AgentMeta, DynamicAgentConfig, IngestOutput, JsonlMapping};
+use crate::store::duckdb::{Session, ToolCall};
+
+/// A generic JSONL adapter configured entirely from YAML.
+#[derive(Debug)]
+pub struct GenericJsonlAdapter {
+    meta: AgentMeta,
+    base_path: PathBuf,
+    mapping: JsonlMapping,
+    file_pattern: Pattern,
+}
+
+impl GenericJsonlAdapter {
+    /// Build an adapter from a dynamic-agent definition.
+    pub fn from_config(config: &DynamicAgentConfig) -> Result<Self> {
+        let mapping = config.jsonl.as_ref().context("missing jsonl mapping")?;
+        let file_pattern = Pattern::new(&mapping.file_pattern)
+            .with_context(|| format!("invalid JSONL file pattern '{}'", mapping.file_pattern))?;
+        if mapping.session_id_path.trim().is_empty() {
+            anyhow::bail!("dynamic agent '{}' has an empty session_id_path", config.id);
+        }
+        if let Some(specification) = mapping.tool_call_type.as_deref()
+            && specification
+                .split_once('=')
+                .is_none_or(|(field, value)| field.trim().is_empty() || value.is_empty())
+        {
+            anyhow::bail!(
+                "dynamic agent '{}' has invalid tool_call_type '{}'; expected 'field=value'",
+                config.id,
+                specification
+            );
+        }
+
+        Ok(Self {
+            meta: AgentMeta {
+                id: config.id.clone(),
+                display_name: config.display_name.clone(),
+                storage_format: "jsonl".into(),
+                default_path: config.path.clone(),
+            },
+            base_path: super::adapter::expand_tilde(&config.path),
+            mapping: mapping.clone(),
+            file_pattern,
+        })
+    }
+
+    fn matched_files(&self) -> Vec<PathBuf> {
+        if !self.base_path.is_dir() {
+            return Vec::new();
+        }
+
+        walk_files(&self.base_path)
+            .into_iter()
+            .filter(|path| {
+                path.strip_prefix(&self.base_path)
+                    .ok()
+                    .and_then(|relative| relative.to_str())
+                    .is_some_and(|relative| self.file_pattern.matches(relative))
+            })
+            .collect()
+    }
+
+    fn parse_files(&self, files: &[PathBuf]) -> IngestOutput {
+        let mut sessions: HashMap<String, Session> = HashMap::new();
+        let mut tool_calls = Vec::new();
+        let mut errors = Vec::new();
+
+        for path in files {
+            let contents = match fs::read_to_string(path) {
+                Ok(contents) => contents,
+                Err(error) => {
+                    errors.push(format!("{}: {error}", path.display()));
+                    continue;
+                }
+            };
+            let project_id = project_from_path(&self.base_path, path);
+
+            for (line_number, line) in contents.lines().enumerate() {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let event: Value = match serde_json::from_str(line) {
+                    Ok(event) => event,
+                    Err(error) => {
+                        errors.push(format!("{}:{}: {error}", path.display(), line_number + 1));
+                        continue;
+                    }
+                };
+
+                let Some(session_id) = json_path(&event, &self.mapping.session_id_path)
+                    .and_then(value_text)
+                    .filter(|id| !id.is_empty())
+                else {
+                    errors.push(format!(
+                        "{}:{}: missing session ID at '{}'",
+                        path.display(),
+                        line_number + 1,
+                        self.mapping.session_id_path
+                    ));
+                    continue;
+                };
+
+                let timestamp = self
+                    .mapping
+                    .timestamp_path
+                    .as_deref()
+                    .and_then(|path| json_path(&event, path))
+                    .and_then(parse_json_timestamp);
+                let content = self
+                    .mapping
+                    .content_path
+                    .as_deref()
+                    .and_then(|path| json_path(&event, path))
+                    .and_then(value_text)
+                    .filter(|content| !content.trim().is_empty());
+                let is_tool_call = self.is_tool_call(&event);
+
+                let session = sessions
+                    .entry(session_id.clone())
+                    .or_insert_with(|| Session {
+                        id: session_id.clone(),
+                        project_id: project_id.clone(),
+                        agent: self.meta.id.clone(),
+                        started_at: timestamp,
+                        ended_at: timestamp,
+                        duration_minutes: None,
+                        message_count: Some(0),
+                        tool_call_count: Some(0),
+                        total_tokens: None,
+                        files_changed: Vec::new(),
+                        summary: None,
+                    });
+
+                session.message_count = session.message_count.map(|count| count + 1);
+                if is_tool_call {
+                    session.tool_call_count = session.tool_call_count.map(|count| count + 1);
+                }
+                if let Some(timestamp) = timestamp {
+                    if session
+                        .started_at
+                        .is_none_or(|existing| timestamp < existing)
+                    {
+                        session.started_at = Some(timestamp);
+                    }
+                    if session.ended_at.is_none_or(|existing| timestamp > existing) {
+                        session.ended_at = Some(timestamp);
+                    }
+                }
+                if session.summary.is_none()
+                    && let Some(summary) = &content
+                {
+                    session.summary = Some(summary.chars().take(240).collect());
+                }
+
+                if is_tool_call {
+                    let tool_name = self
+                        .mapping
+                        .tool_name_path
+                        .as_deref()
+                        .and_then(|path| json_path(&event, path))
+                        .and_then(value_text);
+                    let relative_source = path
+                        .strip_prefix(&self.base_path)
+                        .unwrap_or(path)
+                        .to_string_lossy();
+                    let id = deterministic_tool_id(
+                        &self.meta.id,
+                        &relative_source,
+                        line_number,
+                        &session_id,
+                    );
+                    tool_calls.push(ToolCall {
+                        id,
+                        session_id: Some(session_id),
+                        tool_name,
+                        command: content,
+                        success: None,
+                        error_message: None,
+                        duration_ms: None,
+                        timestamp,
+                    });
+                }
+            }
+        }
+
+        let mut sessions: Vec<Session> = sessions.into_values().collect();
+        sessions.sort_by(|a, b| a.id.cmp(&b.id));
+        tool_calls.sort_by(|a, b| a.id.cmp(&b.id));
+
+        IngestOutput {
+            sessions,
+            tool_calls,
+            memories: Vec::new(),
+            errors,
+        }
+    }
+
+    fn is_tool_call(&self, event: &Value) -> bool {
+        let Some(specification) = self.mapping.tool_call_type.as_deref() else {
+            return self.mapping.tool_name_path.is_some()
+                && self
+                    .mapping
+                    .tool_name_path
+                    .as_deref()
+                    .and_then(|path| json_path(event, path))
+                    .is_some();
+        };
+
+        let Some((field, expected)) = specification.split_once('=') else {
+            return false;
+        };
+        json_path(event, field)
+            .and_then(value_text)
+            .is_some_and(|actual| actual == expected)
+    }
+}
+
+impl AgentAdapter for GenericJsonlAdapter {
+    fn meta(&self) -> &AgentMeta {
+        &self.meta
+    }
+
+    fn detect(&self) -> bool {
+        self.matched_files()
+            .first()
+            .is_some_and(|path| path.is_file())
+    }
+
+    fn ingest(&self) -> Result<IngestOutput> {
+        Ok(self.parse_files(&self.matched_files()))
+    }
+}
+
+fn walk_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+
+    while let Some(directory) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                files.push(path);
+            }
+        }
+    }
+
+    files.sort();
+    files
+}
+
+fn project_from_path(base: &Path, file: &Path) -> Option<String> {
+    let relative = file.strip_prefix(base).ok()?;
+    let mut components = relative.parent()?.components();
+    components
+        .next()
+        .map(|component| component.as_os_str().to_string_lossy().to_string())
+}
+
+fn json_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    path.split('.')
+        .try_fold(value, |current, segment| current.get(segment))
+}
+
+fn value_text(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(text) => Some(text.clone()),
+        Value::Number(number) => Some(number.to_string()),
+        Value::Bool(flag) => Some(flag.to_string()),
+        Value::Array(items) => {
+            let texts: Vec<String> = items.iter().filter_map(value_text).collect();
+            (!texts.is_empty()).then(|| texts.join("\n"))
+        }
+        Value::Object(object) => {
+            let texts: Vec<String> = object.values().filter_map(value_text).collect();
+            (!texts.is_empty()).then(|| texts.join("\n"))
+        }
+    }
+}
+
+fn parse_json_timestamp(value: &Value) -> Option<chrono::NaiveDateTime> {
+    match value {
+        Value::String(text) => chrono::DateTime::parse_from_rfc3339(text)
+            .ok()
+            .map(|timestamp| timestamp.naive_utc())
+            .or_else(|| super::parse_iso_timestamp(text)),
+        Value::Number(number) => {
+            let raw = number.as_f64()?;
+            let seconds = if raw > 1_000_000_000_000.0 {
+                raw / 1_000.0
+            } else {
+                raw
+            };
+            chrono::DateTime::from_timestamp(seconds.floor() as i64, 0)
+                .map(|timestamp| timestamp.naive_utc())
+        }
+        _ => None,
+    }
+}
+
+fn deterministic_tool_id(
+    agent: &str,
+    source: &str,
+    line_number: usize,
+    session_id: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(agent.as_bytes());
+    hasher.update([0]);
+    hasher.update(source.as_bytes());
+    hasher.update([0]);
+    hasher.update(line_number.to_le_bytes());
+    hasher.update([0]);
+    hasher.update(session_id.as_bytes());
+    let digest = hasher.finalize();
+    format!("jsonl-{}", hex_prefix(&digest))
+}
+
+fn hex_prefix(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .take(16)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn adapter_config(path: &Path) -> DynamicAgentConfig {
+        DynamicAgentConfig {
+            id: "custom_agent".into(),
+            display_name: "Custom Agent".into(),
+            enabled: true,
+            path: path.to_string_lossy().to_string(),
+            adapter_type: "jsonl".into(),
+            sqlite: None,
+            jsonl: Some(JsonlMapping {
+                file_pattern: "**/*.jsonl".into(),
+                session_id_path: "sessionId".into(),
+                timestamp_path: Some("timestamp".into()),
+                content_path: Some("message.text".into()),
+                tool_name_path: Some("tool.name".into()),
+                tool_call_type: Some("kind=tool".into()),
+            }),
+        }
+    }
+
+    #[test]
+    fn parses_sessions_and_tool_calls_with_stable_ids() {
+        let root = TempDir::new().unwrap();
+        let project = root.path().join("checkout");
+        fs::create_dir_all(&project).unwrap();
+        fs::write(
+            project.join("session.jsonl"),
+            concat!(
+                "{\"sessionId\":\"s1\",\"timestamp\":\"2026-08-01T12:00:00Z\",\"kind\":\"message\",\"message\":{\"text\":\"First prompt\"}}\n",
+                "{\"sessionId\":\"s1\",\"timestamp\":\"2026-08-01T12:01:00Z\",\"kind\":\"tool\",\"tool\":{\"name\":\"Edit\"},\"message\":{\"text\":\"src/lib.rs\"}}\n"
+            ),
+        )
+        .unwrap();
+
+        let config = adapter_config(root.path());
+        let adapter = GenericJsonlAdapter::from_config(&config).unwrap();
+        assert!(adapter.detect());
+        let output = adapter.ingest().unwrap();
+
+        assert_eq!(output.session_count(), 1);
+        assert_eq!(output.tool_call_count(), 1);
+        assert!(output.errors.is_empty());
+        let session = &output.sessions[0];
+        assert_eq!(session.agent, "custom_agent");
+        assert_eq!(session.project_id.as_deref(), Some("checkout"));
+        assert_eq!(session.message_count, Some(2));
+        assert_eq!(session.tool_call_count, Some(1));
+        assert_eq!(session.summary.as_deref(), Some("First prompt"));
+        assert_eq!(
+            session.started_at.map(|time| time.to_string()).as_deref(),
+            Some("2026-08-01 12:00:00")
+        );
+        assert_eq!(output.tool_calls[0].tool_name.as_deref(), Some("Edit"));
+        assert!(output.tool_calls[0].id.starts_with("jsonl-"));
+
+        let rerun = adapter.ingest().unwrap();
+        assert_eq!(rerun.tool_calls[0].id, output.tool_calls[0].id);
+    }
+
+    #[test]
+    fn malformed_lines_are_reported_without_stopping_ingestion() {
+        let root = TempDir::new().unwrap();
+        fs::create_dir_all(root.path().join("project")).unwrap();
+        fs::write(root.path().join("project").join("bad.jsonl"), "{bad\n").unwrap();
+        fs::write(
+            root.path().join("project").join("good.jsonl"),
+            "{\"sessionId\":\"good\"}\n",
+        )
+        .unwrap();
+
+        let adapter = GenericJsonlAdapter::from_config(&adapter_config(root.path())).unwrap();
+        let output = adapter.ingest().unwrap();
+        assert_eq!(output.session_count(), 1);
+        assert_eq!(output.errors.len(), 1);
+        assert!(output.errors[0].contains("bad.jsonl:1"));
+    }
+
+    #[test]
+    fn invalid_pattern_is_rejected() {
+        let root = TempDir::new().unwrap();
+        let mut config = adapter_config(root.path());
+        config.jsonl.as_mut().unwrap().file_pattern = "[invalid".into();
+        assert!(GenericJsonlAdapter::from_config(&config).is_err());
+    }
+
+    #[test]
+    fn invalid_tool_call_selector_is_rejected() {
+        let root = TempDir::new().unwrap();
+        let mut config = adapter_config(root.path());
+        config.jsonl.as_mut().unwrap().tool_call_type = Some("tool".into());
+        let error = GenericJsonlAdapter::from_config(&config).unwrap_err();
+        assert!(error.to_string().contains("expected 'field=value'"));
+    }
+
+    #[test]
+    fn empty_session_path_is_rejected() {
+        let root = TempDir::new().unwrap();
+        let mut config = adapter_config(root.path());
+        config.jsonl.as_mut().unwrap().session_id_path = String::new();
+        let error = GenericJsonlAdapter::from_config(&config).unwrap_err();
+        assert!(error.to_string().contains("empty session_id_path"));
+    }
+
+    #[test]
+    fn missing_mapping_is_rejected() {
+        let root = TempDir::new().unwrap();
+        let mut config = adapter_config(root.path());
+        config.jsonl = None;
+        let error = GenericJsonlAdapter::from_config(&config).unwrap_err();
+        assert!(error.to_string().contains("missing jsonl mapping"));
+    }
+}

--- a/engine/src/ingest/mod.rs
+++ b/engine/src/ingest/mod.rs
@@ -2,6 +2,7 @@ pub mod adapter;
 pub mod claude;
 pub mod codex;
 pub mod gemini;
+pub mod jsonl_adapter;
 pub mod native_adapters;
 #[cfg(feature = "sqlite-adapters")]
 pub mod sqlite_adapter;
@@ -12,7 +13,10 @@ pub use adapter::{AdapterRegistry, AgentAdapter, AgentMeta, DynamicAgentConfig, 
 pub use claude::ClaudeIngester;
 pub use codex::CodexIngester;
 pub use gemini::GeminiIngester;
-pub use native_adapters::{ClaudeAdapter, CodexAdapter, GeminiAdapter, build_default_registry};
+pub use jsonl_adapter::GenericJsonlAdapter;
+pub use native_adapters::{
+    ClaudeAdapter, CodexAdapter, GeminiAdapter, build_default_registry, build_registry_from_config,
+};
 #[cfg(feature = "sqlite-adapters")]
 pub use sqlite_adapter::GenericSqliteAdapter;
 

--- a/engine/src/ingest/native_adapters.rs
+++ b/engine/src/ingest/native_adapters.rs
@@ -3,13 +3,15 @@
 //! These wrap the existing parser implementations behind the [`AgentAdapter`]
 //! trait so they can be used through the unified [`AdapterRegistry`].
 
-use anyhow::Result;
+use anyhow::{Result, bail};
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use super::adapter::{AgentAdapter, AgentMeta, IngestOutput, expand_tilde};
 use super::claude::ClaudeIngester;
 use super::codex::CodexIngester;
 use super::gemini::GeminiIngester;
+use crate::config::AppConfig;
 
 // ---------------------------------------------------------------------------
 // Claude Code adapter
@@ -178,6 +180,67 @@ pub fn build_default_registry() -> super::adapter::AdapterRegistry {
     registry
 }
 
+/// Build an adapter registry from user configuration.
+///
+/// Native paths and `enabled` flags are honoured, as are configured dynamic
+/// SQLite agents. Unsupported dynamic adapter types are rejected rather than
+/// being silently ignored.
+pub fn build_registry_from_config(config: &AppConfig) -> Result<super::adapter::AdapterRegistry> {
+    let mut registry = super::adapter::AdapterRegistry::new();
+    let mut configured_ids = HashSet::new();
+
+    if config.agents.claude_code.enabled {
+        configured_ids.insert("claude_code");
+        registry.register(Box::new(ClaudeAdapter::new(
+            &config.agents.claude_code.path,
+        )));
+    }
+    if config.agents.codex.enabled {
+        configured_ids.insert("codex");
+        registry.register(Box::new(CodexAdapter::new(&config.agents.codex.path)));
+    }
+    if config.agents.gemini.enabled {
+        configured_ids.insert("gemini");
+        registry.register(Box::new(GeminiAdapter::new(&config.agents.gemini.path)));
+    }
+
+    for agent in &config.agents.dynamic {
+        if !configured_ids.insert(agent.id.as_str()) {
+            bail!("duplicate agent id '{}'", agent.id);
+        }
+        if !agent.enabled {
+            continue;
+        }
+        match agent.adapter_type.as_str() {
+            "sqlite" => {
+                #[cfg(feature = "sqlite-adapters")]
+                {
+                    let adapter = super::sqlite_adapter::GenericSqliteAdapter::from_config(agent)
+                        .ok_or_else(|| {
+                        anyhow::anyhow!("dynamic agent '{}' is missing SQLite mappings", agent.id)
+                    })?;
+                    registry.register(Box::new(adapter));
+                }
+                #[cfg(not(feature = "sqlite-adapters"))]
+                bail!(
+                    "dynamic agent '{}' requires the sqlite-adapters feature",
+                    agent.id
+                );
+            }
+            "jsonl" => {
+                let adapter = super::jsonl_adapter::GenericJsonlAdapter::from_config(agent)?;
+                registry.register(Box::new(adapter));
+            }
+            other => bail!(
+                "unsupported adapter type '{other}' for agent '{}'",
+                agent.id
+            ),
+        }
+    }
+
+    Ok(registry)
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -274,6 +337,110 @@ mod tests {
         assert!(reg.get("claude_code").is_some());
         assert!(reg.get("codex").is_some());
         assert!(reg.get("gemini").is_some());
+    }
+
+    #[test]
+    fn test_registry_from_config_honours_enabled_and_paths() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("projects")).unwrap();
+
+        let mut config = crate::config::AppConfig::default();
+        config.agents.claude_code.path = tmp.path().to_string_lossy().to_string();
+        config.agents.codex.enabled = false;
+        config.agents.gemini.enabled = false;
+
+        let registry = build_registry_from_config(&config).unwrap();
+        assert_eq!(registry.agent_ids(), vec!["claude_code"]);
+        assert_eq!(registry.detected_ids(), vec!["claude_code"]);
+    }
+
+    #[test]
+    fn test_registry_from_config_rejects_unknown_adapter() {
+        let mut config = crate::config::AppConfig::default();
+        config.agents.claude_code.enabled = false;
+        config.agents.codex.enabled = false;
+        config.agents.gemini.enabled = false;
+        config.agents.dynamic = vec![super::super::adapter::DynamicAgentConfig {
+            id: "unsupported".into(),
+            display_name: "Unsupported".into(),
+            enabled: true,
+            path: "/tmp/unsupported".into(),
+            adapter_type: "parquet".into(),
+            sqlite: None,
+            jsonl: None,
+        }];
+
+        let Err(error) = build_registry_from_config(&config) else {
+            panic!("unsupported dynamic adapter should be rejected");
+        };
+        assert!(error.to_string().contains("unsupported adapter type"));
+    }
+
+    #[test]
+    fn test_registry_from_config_rejects_duplicate_agent_ids() {
+        let mut config = crate::config::AppConfig::default();
+        config.agents.dynamic = vec![
+            super::super::adapter::DynamicAgentConfig {
+                id: "duplicate".into(),
+                display_name: "First".into(),
+                enabled: false,
+                path: "/tmp/first".into(),
+                adapter_type: "jsonl".into(),
+                sqlite: None,
+                jsonl: None,
+            },
+            super::super::adapter::DynamicAgentConfig {
+                id: "duplicate".into(),
+                display_name: "Second".into(),
+                enabled: false,
+                path: "/tmp/second".into(),
+                adapter_type: "jsonl".into(),
+                sqlite: None,
+                jsonl: None,
+            },
+        ];
+
+        let Err(error) = build_registry_from_config(&config) else {
+            panic!("duplicate agent IDs should be rejected");
+        };
+        assert!(error.to_string().contains("duplicate agent id 'duplicate'"));
+    }
+
+    #[test]
+    fn test_registry_from_config_builds_generic_jsonl_adapter() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("project")).unwrap();
+        fs::write(
+            tmp.path().join("project").join("session.jsonl"),
+            "{\"sessionId\":\"dynamic-1\",\"message\":{\"text\":\"hello\"}}\n",
+        )
+        .unwrap();
+
+        let mut config = crate::config::AppConfig::default();
+        config.agents.claude_code.enabled = false;
+        config.agents.codex.enabled = false;
+        config.agents.gemini.enabled = false;
+        config.agents.dynamic = vec![super::super::adapter::DynamicAgentConfig {
+            id: "custom_jsonl".into(),
+            display_name: "Custom JSONL".into(),
+            enabled: true,
+            path: tmp.path().to_string_lossy().to_string(),
+            adapter_type: "jsonl".into(),
+            sqlite: None,
+            jsonl: Some(super::super::adapter::JsonlMapping {
+                file_pattern: "**/*.jsonl".into(),
+                session_id_path: "sessionId".into(),
+                timestamp_path: None,
+                content_path: Some("message.text".into()),
+                tool_name_path: None,
+                tool_call_type: None,
+            }),
+        }];
+
+        let registry = build_registry_from_config(&config).unwrap();
+        assert_eq!(registry.detected_ids(), vec!["custom_jsonl"]);
+        let output = registry.ingest_agent("custom_jsonl").unwrap();
+        assert_eq!(output.session_count(), 1);
     }
 
     #[test]

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -25,7 +25,7 @@ pub use consolidate::{
     ConsolidationStats, DecayScore, MergeCandidate, compute_decay_scores, consolidate,
 };
 pub use context::{AgentContext, ContextAssembler, PressureLevel};
-pub use detect::{AgentDetection, AgentInfo, detect_agents};
+pub use detect::{AgentDetection, AgentInfo, detect_agents, detect_agents_from};
 pub use distill::{DistilledSession, Distiller, LlmClient};
 pub use embed_pipeline::{EmbedChunk, EmbedPipeline, EmbedStats, Granularity};
 pub use embedding::{EmbedProvider, LmStudioEmbedder, MockEmbedder, batch_embed};

--- a/engine/src/pipeline.rs
+++ b/engine/src/pipeline.rs
@@ -58,6 +58,14 @@ impl IngestPipeline {
     pub fn ingest_claude(&self) -> Result<IngestResult> {
         info!("starting Claude Code ingestion");
         let ingester = ClaudeIngester::new()?;
+        self.ingest_claude_from(&ingester)
+    }
+
+    /// Ingest Claude Code artifacts from an explicit ingester.
+    ///
+    /// This dependency-injection point keeps tests isolated from the current
+    /// user's real `~/.claude` directory.
+    pub fn ingest_claude_from(&self, ingester: &ClaudeIngester) -> Result<IngestResult> {
         let data = ingester.ingest_all()?;
 
         let mut result = IngestResult::new("claude_code");
@@ -104,6 +112,11 @@ impl IngestPipeline {
                 return Ok(IngestResult::new("codex"));
             }
         };
+        self.ingest_codex_from(&ingester)
+    }
+
+    /// Ingest Codex artifacts from an explicit ingester.
+    pub fn ingest_codex_from(&self, ingester: &CodexIngester) -> Result<IngestResult> {
         let data = ingester.ingest_all()?;
 
         let mut result = IngestResult::new("codex");
@@ -147,6 +160,11 @@ impl IngestPipeline {
                 return Ok(IngestResult::new("gemini"));
             }
         };
+        self.ingest_gemini_from(&ingester)
+    }
+
+    /// Ingest Gemini artifacts from an explicit ingester.
+    pub fn ingest_gemini_from(&self, ingester: &GeminiIngester) -> Result<IngestResult> {
         let (mut result, sessions, tool_calls, memories) = ingester.ingest_all();
 
         for session in &sessions {
@@ -186,18 +204,31 @@ mod tests {
 
     #[test]
     fn test_pipeline_handles_empty_gracefully() {
-        // In-memory DuckDB, no agent dirs exist -> should return Ok with
-        // empty or zero results, not crash.
+        use tempfile::TempDir;
+
+        // In-memory DuckDB plus explicitly empty agent roots. Tests must never
+        // read (or, worse, ingest) the developer's real multi-gigabyte agent
+        // history just to exercise the empty path.
+        let home = TempDir::new().expect("create isolated agent root");
         let store = DuckStore::open_in_memory().expect("open in-memory DuckDB");
         let pipeline = IngestPipeline::new(store);
-        let results = pipeline
-            .run_full_ingest()
-            .expect("full ingest should not fail");
+        let claude = pipeline
+            .ingest_claude_from(&ClaudeIngester::with_base_path(home.path().join(".claude")))
+            .expect("empty Claude ingest");
+        let codex = pipeline
+            .ingest_codex_from(&CodexIngester::with_base_path(home.path().join(".codex")))
+            .expect("empty Codex ingest");
+        let gemini = pipeline
+            .ingest_gemini_from(&GeminiIngester::with_base_path(home.path().join(".gemini")))
+            .expect("empty Gemini ingest");
+        let results = [claude, codex, gemini];
 
         // Each agent either returns empty results or is skipped entirely.
-        for r in &results {
-            assert!(r.errors.is_empty() || !r.errors.is_empty()); // doesn't panic
-        }
+        assert_eq!(results.len(), 3);
+        assert!(results.iter().all(|r| r.errors.is_empty()));
+        assert!(results.iter().all(|r| r.sessions_found == 0));
+        assert!(results.iter().all(|r| r.tool_calls_found == 0));
+        assert!(results.iter().all(|r| r.memories_found == 0));
     }
 
     #[test]
@@ -268,7 +299,9 @@ mod tests {
         assert_eq!(sessions[0].summary.as_deref(), Some("updated summary"));
 
         let memories = store.search_memories("important").expect("search memories");
-        assert_eq!(memories.len(), 1);
-        assert_eq!(memories[0].id, "mem-1");
+        assert!(
+            memories.is_empty(),
+            "replacing a session must remove its old derived memories"
+        );
     }
 }

--- a/engine/src/repo_embed.rs
+++ b/engine/src/repo_embed.rs
@@ -3,6 +3,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
 // Conditional imports for code-analysis feature
@@ -72,6 +73,23 @@ const SKIP_DIRS: &[&str] = &[
 /// indicating likely binary content.
 fn looks_binary(buf: &[u8]) -> bool {
     buf.contains(&0)
+}
+
+/// Stable fallback ID for builds without BLAKE3/Infiniloom.
+///
+/// It includes project, path, line span, and content so a changed file gets a
+/// new ID even when AST chunk metadata is unavailable.
+fn stable_chunk_id(project_id: &str, chunk: &CodeChunk) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(project_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(chunk.file_path.as_bytes());
+    hasher.update([0]);
+    hasher.update(chunk.start_line.to_le_bytes());
+    hasher.update(chunk.end_line.to_le_bytes());
+    hasher.update([0]);
+    hasher.update(chunk.content.as_bytes());
+    format!("{:x}", hasher.finalize())
 }
 
 // ---------------------------------------------------------------------------
@@ -462,7 +480,7 @@ impl RepoEmbedder {
                 }
             }
 
-            return Ok(chunks);
+            Ok(chunks)
         }
 
         // Fallback: naive line-based chunker (no feature flag).
@@ -478,6 +496,12 @@ impl RepoEmbedder {
     /// `IncrementalScanner` to skip files that haven't changed since the last
     /// run (based on mtime + size + content hash).
     pub fn chunk_all(&self) -> Result<(Vec<CodeChunk>, usize)> {
+        self.chunk_all_with_mode(false)
+    }
+
+    /// Discover and chunk files, optionally forcing changed-file caches to be
+    /// ignored. A forced scan is used by `rem embed --update`.
+    pub fn chunk_all_with_mode(&self, _force_rescan: bool) -> Result<(Vec<CodeChunk>, usize)> {
         let files = self.discover_files()?;
         let file_count = files.len();
         info!(files = file_count, root = %self.root.display(), "discovered files");
@@ -491,7 +515,7 @@ impl RepoEmbedder {
 
             for file in &files {
                 // Skip files that haven't changed since last scan.
-                if !scanner.needs_rescan(file) {
+                if !_force_rescan && !scanner.needs_rescan(file) {
                     skipped += 1;
                     continue;
                 }
@@ -580,7 +604,35 @@ impl RepoEmbedder {
         lance_store: &crate::store::LanceStore,
         batch_size: usize,
     ) -> Result<EmbedResult> {
-        let (chunks, file_count) = self.chunk_all()?;
+        self.embed_and_store_with_update(provider, lance_store, batch_size, false)
+            .await
+    }
+
+    /// Embed and store chunks, optionally replacing all prior embeddings for
+    /// this project. The non-update path is idempotent for unchanged chunks.
+    pub async fn embed_and_store_with_update<P: crate::embedding::EmbedProvider>(
+        &self,
+        provider: &P,
+        lance_store: &crate::store::LanceStore,
+        batch_size: usize,
+        update: bool,
+    ) -> Result<EmbedResult> {
+        let (mut chunks, file_count) = self.chunk_all_with_mode(update)?;
+        if !update {
+            let existing_ids: std::collections::HashSet<String> = lance_store
+                .get_code_embedding_ids_for_project(&self.project_id)
+                .await?
+                .into_iter()
+                .collect();
+            chunks.retain(|chunk| {
+                let chunk_id = chunk
+                    .blake3_id
+                    .clone()
+                    .unwrap_or_else(|| stable_chunk_id(&self.project_id, chunk));
+                !existing_ids.contains(&chunk_id)
+            });
+        }
+
         let total_chunks = chunks.len();
 
         let mut result = EmbedResult {
@@ -621,6 +673,11 @@ impl RepoEmbedder {
         }
 
         // Store each chunk with its embedding.
+        if update && total_chunks > 0 && all_vectors.iter().any(|vector| !vector.is_empty()) {
+            lance_store
+                .delete_code_embeddings_for_project(&self.project_id)
+                .await?;
+        }
         for (idx, chunk) in chunks.iter().enumerate() {
             let embedding = &all_vectors[idx];
             if embedding.is_empty() {
@@ -629,12 +686,10 @@ impl RepoEmbedder {
             }
 
             // Use BLAKE3 ID when available, otherwise fall back to positional ID.
-            let id = chunk.blake3_id.clone().unwrap_or_else(|| {
-                format!(
-                    "{}:{}:{}:{}",
-                    self.project_id, chunk.file_path, chunk.start_line, chunk.end_line
-                )
-            });
+            let id = chunk
+                .blake3_id
+                .clone()
+                .unwrap_or_else(|| stable_chunk_id(&self.project_id, chunk));
 
             match lance_store
                 .insert_code_embedding(
@@ -941,6 +996,71 @@ mod tests {
         assert_eq!(result.findings_count, 0);
         assert_eq!(result.critical_count, 0);
         assert_eq!(result.high_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_repository_embedding_is_idempotent_and_update_replaces() {
+        use crate::embedding::MockEmbedder;
+        use crate::store::LanceStore;
+
+        let directory = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        fs::write(root.path().join("main.rs"), "fn original() {}\n").unwrap();
+
+        let lance = LanceStore::open_with_dim(directory.path(), 8)
+            .await
+            .unwrap();
+        let embedder = RepoEmbedder::new(root.path());
+        let provider = MockEmbedder::new(8);
+
+        let first = embedder
+            .embed_and_store(&provider, &lance, 10)
+            .await
+            .unwrap();
+        assert_eq!(first.chunks_embedded, 1);
+        assert_eq!(
+            lance
+                .get_code_embedding_ids_for_project(embedder.project_id())
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let unchanged = embedder
+            .embed_and_store(&provider, &lance, 10)
+            .await
+            .unwrap();
+        assert_eq!(unchanged.chunks_embedded, 0);
+
+        fs::write(root.path().join("main.rs"), "fn replacement() {}\n").unwrap();
+        let changed = embedder
+            .embed_and_store(&provider, &lance, 10)
+            .await
+            .unwrap();
+        assert_eq!(changed.chunks_embedded, 1);
+        assert_eq!(
+            lance
+                .get_code_embedding_ids_for_project(embedder.project_id())
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+
+        let updated = embedder
+            .embed_and_store_with_update(&provider, &lance, 10, true)
+            .await
+            .unwrap();
+        assert_eq!(updated.chunks_embedded, 1);
+        assert_eq!(
+            lance
+                .get_code_embedding_ids_for_project(embedder.project_id())
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
     }
 }
 

--- a/engine/src/semantic_tree.rs
+++ b/engine/src/semantic_tree.rs
@@ -306,7 +306,7 @@ impl<'a> TreeBuilder<'a> {
 
     /// Build the root node with project children (level 1 only).
     pub fn build_root(&self) -> Result<TreeNode> {
-        let mut root = TreeNode::new("root", TreeNodeType::Root, "Remembrant");
+        let mut root = TreeNode::new("Root", TreeNodeType::Root, "Remembrant");
         root.text_repr = "Remembrant Memory Store".to_string();
 
         let project_ids = self.store.get_project_ids()?;
@@ -375,7 +375,7 @@ impl<'a> TreeBuilder<'a> {
     /// Parses the node ID prefix to determine type (e.g., "project:", "session:")
     /// and queries accordingly.
     pub fn find_node(&self, node_id: &str) -> Result<Option<TreeNode>> {
-        if node_id == "root" {
+        if node_id.eq_ignore_ascii_case("root") {
             let root = self.build_root()?;
             return Ok(Some(root));
         }
@@ -1366,9 +1366,14 @@ mod tests {
         let store = setup_test_store();
         let builder = TreeBuilder::new(&store);
 
-        let node = builder.find_node("root").unwrap();
+        let node = builder.find_node("Root").unwrap();
         assert!(node.is_some());
-        assert_eq!(node.unwrap().node_type, TreeNodeType::Root);
+        let node = node.unwrap();
+        assert_eq!(node.node_type, TreeNodeType::Root);
+        assert_eq!(node.id, "Root");
+
+        // Lookup is case-insensitive for the root node.
+        assert!(builder.find_node("root").unwrap().is_some());
     }
 
     #[test]

--- a/engine/src/store/duckdb.rs
+++ b/engine/src/store/duckdb.rs
@@ -4,6 +4,7 @@ use duckdb::{Connection, params};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::sync::Mutex;
+use tracing::warn;
 
 // ---------------------------------------------------------------------------
 // Domain structs
@@ -151,6 +152,42 @@ fn json_to_vec(s: &str) -> Vec<String> {
     serde_json::from_str(s).unwrap_or_default()
 }
 
+/// Delete a graph node and incident edges before a relational transaction.
+///
+/// DuckDB's foreign-key implementation can reject a parent-node deletion in
+/// the same transaction that removes its child edges. Graph cleanup is therefore
+/// committed first; callers rebuild derived graph nodes after relational writes.
+fn delete_graph_node_with_edges(conn: &mut duckdb::Connection, node_id: &str) -> Result<()> {
+    conn.execute(
+        "DELETE FROM graph_edges WHERE from_id = ? OR to_id = ?",
+        params![node_id, node_id],
+    )
+    .context("failed to delete graph edges")?;
+    conn.execute("DELETE FROM graph_nodes WHERE id = ?", params![node_id])
+        .context("failed to delete graph node")?;
+    Ok(())
+}
+
+fn normalize_tags(tags: &[String]) -> Result<Vec<String>> {
+    let mut normalized = Vec::new();
+    for tag in tags {
+        let tag = tag.trim();
+        if tag.is_empty() {
+            anyhow::bail!("tags cannot be empty");
+        }
+        if tag.len() > 80 {
+            anyhow::bail!("tag exceeds 80 characters: {tag}");
+        }
+        if !normalized
+            .iter()
+            .any(|existing: &String| existing.eq_ignore_ascii_case(tag))
+        {
+            normalized.push(tag.to_string());
+        }
+    }
+    Ok(normalized)
+}
+
 // ---------------------------------------------------------------------------
 // Graph row structs (for DuckPGQ-backed graph storage)
 // ---------------------------------------------------------------------------
@@ -266,6 +303,14 @@ impl DuckStore {
                 created_at TIMESTAMP DEFAULT current_timestamp,
                 updated_at TIMESTAMP DEFAULT current_timestamp,
                 valid_until TIMESTAMP
+            );
+
+            CREATE TABLE IF NOT EXISTS memory_tags (
+                memory_id TEXT NOT NULL,
+                tag TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT current_timestamp,
+                PRIMARY KEY (memory_id, tag),
+                FOREIGN KEY (memory_id) REFERENCES memories(id)
             );
 
             CREATE TABLE IF NOT EXISTS tool_calls (
@@ -736,37 +781,101 @@ impl DuckStore {
         Ok(())
     }
 
-    /// Insert or replace a session record (upsert).
+    /// Replace a session and its transcript-derived relational rows.
     ///
-    /// If a session with the same `id` already exists, it is replaced with
-    /// the new data. This makes re-ingestion idempotent.
+    /// Re-ingestion is idempotent. DuckDB cannot reliably delete graph parent
+    /// nodes and child edges in one transaction, so stale derived graph nodes
+    /// are removed first; callers rebuild the graph after successful writes.
     pub fn insert_or_replace_session(&self, session: &Session) -> Result<()> {
-        let conn = self.conn.lock().expect("lock poisoned");
+        let mut conn = self.conn.lock().expect("lock poisoned");
         let files_json = vec_to_json(&session.files_changed);
+
+        let stale_graph_ids: Vec<String> = {
+            let mut statement = conn
+                .prepare(
+                    "SELECT 'session:' || ? AS graph_id
+                     UNION ALL
+                     SELECT 'memory:' || id FROM memories WHERE source_session_id = ?
+                     UNION ALL
+                     SELECT 'decision:' || id FROM decisions WHERE session_id = ?",
+                )
+                .context("failed to prepare stale graph lookup")?;
+            let rows = statement
+                .query_map(params![session.id, session.id, session.id], |row| {
+                    row.get::<_, String>(0)
+                })
+                .context("failed to query stale graph IDs")?;
+            let mut ids = Vec::new();
+            for row in rows {
+                ids.push(row.context("failed to read stale graph ID")?);
+            }
+            ids
+        };
+        for graph_id in &stale_graph_ids {
+            delete_graph_node_with_edges(&mut conn, graph_id)?;
+        }
         conn.execute(
-            "INSERT OR REPLACE INTO sessions (
-                id, project_id, agent, started_at, ended_at,
-                duration_minutes, message_count, tool_call_count,
-                total_tokens, files_changed, summary
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            params![
-                session.id,
-                session.project_id,
-                session.agent,
-                session.started_at,
-                session.ended_at,
-                session.duration_minutes,
-                session.message_count,
-                session.tool_call_count,
-                session.total_tokens,
-                files_json,
-                session.summary,
-            ],
+            "DELETE FROM memory_tags WHERE memory_id IN (
+                SELECT id FROM memories WHERE source_session_id = ?
+            )",
+            params![session.id],
         )
-        .context("failed to insert_or_replace session")?;
+        .context("failed to delete old session memory tags")?;
+
+        let transaction = conn
+            .transaction()
+            .context("failed to begin session replacement transaction")?;
+        transaction
+            .execute(
+                "DELETE FROM tool_calls WHERE session_id = ?",
+                params![session.id],
+            )
+            .context("failed to delete old session tool calls")?;
+        transaction
+            .execute(
+                "DELETE FROM memories WHERE source_session_id = ?",
+                params![session.id],
+            )
+            .context("failed to delete old session memories")?;
+        transaction
+            .execute(
+                "DELETE FROM decisions WHERE session_id = ?",
+                params![session.id],
+            )
+            .context("failed to delete old session decisions")?;
+        transaction
+            .execute(
+                "DELETE FROM facts WHERE source_session_id = ?",
+                params![session.id],
+            )
+            .context("failed to delete old session facts")?;
+        transaction
+            .execute(
+                "INSERT OR REPLACE INTO sessions (
+                    id, project_id, agent, started_at, ended_at,
+                    duration_minutes, message_count, tool_call_count,
+                    total_tokens, files_changed, summary
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    session.id,
+                    session.project_id,
+                    session.agent,
+                    session.started_at,
+                    session.ended_at,
+                    session.duration_minutes,
+                    session.message_count,
+                    session.tool_call_count,
+                    session.total_tokens,
+                    files_json,
+                    session.summary,
+                ],
+            )
+            .context("failed to insert_or_replace session")?;
+        transaction
+            .commit()
+            .context("failed to commit session replacement transaction")?;
         Ok(())
     }
-
     /// Insert a memory record.
     pub fn insert_memory(&self, memory: &Memory) -> Result<()> {
         let conn = self.conn.lock().expect("lock poisoned");
@@ -848,10 +957,22 @@ impl DuckStore {
 
     /// Delete a memory by ID.
     pub fn delete_memory(&self, memory_id: &str) -> Result<bool> {
-        let conn = self.conn.lock().expect("lock poisoned");
-        let affected = conn
+        let mut conn = self.conn.lock().expect("lock poisoned");
+        delete_graph_node_with_edges(&mut conn, &format!("memory:{memory_id}"))?;
+        conn.execute(
+            "DELETE FROM memory_tags WHERE memory_id = ?",
+            params![memory_id],
+        )
+        .context("failed to delete memory tags")?;
+        let transaction = conn
+            .transaction()
+            .context("failed to begin memory deletion transaction")?;
+        let affected = transaction
             .execute("DELETE FROM memories WHERE id = ?", params![memory_id])
             .context("failed to delete memory")?;
+        transaction
+            .commit()
+            .context("failed to commit memory deletion transaction")?;
         Ok(affected > 0)
     }
 
@@ -1406,6 +1527,43 @@ impl DuckStore {
         Ok(sessions)
     }
 
+    /// Return a session by its exact identifier.
+    pub fn get_session(&self, session_id: &str) -> Result<Option<Session>> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, project_id, agent, started_at, ended_at,
+                        duration_minutes, message_count, tool_call_count,
+                        total_tokens, files_changed, summary
+                 FROM sessions
+                 WHERE id = ?",
+            )
+            .context("failed to prepare get_session")?;
+
+        let mut rows = stmt
+            .query_map(params![session_id], |row| {
+                let files_str: String = row.get::<_, String>(9).unwrap_or_default();
+                Ok(Session {
+                    id: row.get(0)?,
+                    project_id: row.get(1)?,
+                    agent: row.get(2)?,
+                    started_at: row.get(3)?,
+                    ended_at: row.get(4)?,
+                    duration_minutes: row.get(5)?,
+                    message_count: row.get(6)?,
+                    tool_call_count: row.get(7)?,
+                    total_tokens: row.get(8)?,
+                    files_changed: json_to_vec(&files_str),
+                    summary: row.get(10)?,
+                })
+            })
+            .context("failed to query session by id")?;
+
+        rows.next()
+            .transpose()
+            .context("failed to read session by id")
+    }
+
     /// Search sessions by agent, project, or since date.
     pub fn search_sessions(
         &self,
@@ -1482,10 +1640,14 @@ impl DuckStore {
         Ok(sessions)
     }
 
-    /// Get sessions from today (last 24 hours).
+    /// Get all sessions from the current UTC calendar day.
     pub fn get_todays_sessions(&self) -> Result<Vec<Session>> {
-        let since = Utc::now().naive_utc() - chrono::Duration::hours(24);
-        self.search_sessions(None, None, Some(since), 1000)
+        let now = Utc::now().naive_utc();
+        let since = now
+            .date()
+            .and_hms_opt(0, 0, 0)
+            .context("failed to calculate UTC day boundary")?;
+        self.search_sessions(None, None, Some(since), i32::MAX as usize)
     }
 
     /// Get tool calls for a session.
@@ -1660,6 +1822,233 @@ impl DuckStore {
         Ok(count as usize)
     }
 
+    /// Count sessions since a given timestamp.
+    pub fn count_sessions_since(&self, since: NaiveDateTime) -> Result<usize> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE started_at >= ?",
+                params![since],
+                |row| row.get(0),
+            )
+            .context("failed to count sessions since")?;
+        Ok(count as usize)
+    }
+
+    /// Count memories since a given timestamp.
+    pub fn count_memories_since(&self, since: NaiveDateTime) -> Result<usize> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE created_at >= ?",
+                params![since],
+                |row| row.get(0),
+            )
+            .context("failed to count memories since")?;
+        Ok(count as usize)
+    }
+
+    /// Count decisions since a given timestamp.
+    pub fn count_decisions_since(&self, since: NaiveDateTime) -> Result<usize> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM decisions WHERE created_at >= ?",
+                params![since],
+                |row| row.get(0),
+            )
+            .context("failed to count decisions since")?;
+        Ok(count as usize)
+    }
+
+    /// Count tool calls since a given timestamp.
+    pub fn count_tool_calls_since(&self, since: NaiveDateTime) -> Result<usize> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM tool_calls WHERE timestamp >= ?",
+                params![since],
+                |row| row.get(0),
+            )
+            .context("failed to count tool calls since")?;
+        Ok(count as usize)
+    }
+
+    /// Get distinct agent names active since a timestamp.
+    pub fn get_active_agents_since(&self, since: NaiveDateTime) -> Result<Vec<String>> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let mut stmt = conn
+            .prepare("SELECT DISTINCT agent FROM sessions WHERE started_at >= ? ORDER BY agent")
+            .context("failed to prepare active agents since")?;
+        let rows = stmt
+            .query_map(params![since], |row| row.get::<_, String>(0))
+            .context("failed to query active agents since")?;
+        let mut agents = Vec::new();
+        for row in rows {
+            agents.push(row.context("failed to read agent row")?);
+        }
+        Ok(agents)
+    }
+
+    /// Get per-day session counts for the last N days (for sparklines).
+    pub fn get_daily_session_counts(&self, days: i64) -> Result<Vec<i64>> {
+        Ok(self
+            .get_daily_counts(days)?
+            .into_iter()
+            .map(|(_, sessions, _, _)| sessions)
+            .collect())
+    }
+
+    /// Get per-day memory counts for the last N days (for sparklines).
+    pub fn get_daily_memory_counts(&self, days: i64) -> Result<Vec<i64>> {
+        Ok(self
+            .get_daily_counts(days)?
+            .into_iter()
+            .map(|(_, _, memories, _)| memories)
+            .collect())
+    }
+
+    /// Get per-day decision counts for the last N days (for sparklines).
+    pub fn get_daily_decision_counts(&self, days: i64) -> Result<Vec<i64>> {
+        Ok(self
+            .get_daily_counts(days)?
+            .into_iter()
+            .map(|(_, _, _, decisions)| decisions)
+            .collect())
+    }
+
+    /// Returns (date_str, sessions_count, memories_count, decisions_count) for each of the last N days.
+    pub fn get_daily_counts(&self, days: i64) -> Result<Vec<(String, i64, i64, i64)>> {
+        let days = days.max(0);
+        let conn = self.conn.lock().expect("lock poisoned");
+
+        let now = Utc::now().naive_utc();
+        let today_start = now.date().and_hms_opt(0, 0, 0).context("invalid date")?;
+        let cutoff = today_start - chrono::Duration::days(days);
+
+        // Query each table separately and merge in Rust
+        let mut sess_map = std::collections::HashMap::<String, i64>::new();
+        let mut stmt = conn
+            .prepare(
+                "SELECT CAST(started_at AS DATE)::VARCHAR AS day, COUNT(*) AS cnt
+                 FROM sessions
+                 WHERE started_at >= ?
+                 GROUP BY day
+                 ORDER BY day",
+            )
+            .context("failed to prepare daily sessions count")?;
+        let rows = stmt
+            .query_map(params![cutoff], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .context("failed to query daily sessions")?;
+        for row in rows {
+            let (d, c) = row.context("failed to read session count row")?;
+            sess_map.insert(d, c);
+        }
+
+        let mut mem_map = std::collections::HashMap::<String, i64>::new();
+        let mut stmt = conn
+            .prepare(
+                "SELECT CAST(created_at AS DATE)::VARCHAR AS day, COUNT(*) AS cnt
+                 FROM memories
+                 WHERE created_at >= ?
+                 GROUP BY day
+                 ORDER BY day",
+            )
+            .context("failed to prepare daily memories count")?;
+        let rows = stmt
+            .query_map(params![cutoff], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .context("failed to query daily memories")?;
+        for row in rows {
+            let (d, c) = row.context("failed to read memory count row")?;
+            mem_map.insert(d, c);
+        }
+
+        let mut dec_map = std::collections::HashMap::<String, i64>::new();
+        let mut stmt = conn
+            .prepare(
+                "SELECT CAST(created_at AS DATE)::VARCHAR AS day, COUNT(*) AS cnt
+                 FROM decisions
+                 WHERE created_at >= ?
+                 GROUP BY day
+                 ORDER BY day",
+            )
+            .context("failed to prepare daily decisions count")?;
+        let rows = stmt
+            .query_map(params![cutoff], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .context("failed to query daily decisions")?;
+        for row in rows {
+            let (d, c) = row.context("failed to read decision count row")?;
+            dec_map.insert(d, c);
+        }
+
+        // Build ordered result for each day in the range
+        let today = now.date();
+        let mut result = Vec::new();
+        for i in (0..=days).rev() {
+            let date = today - chrono::Duration::days(i);
+            let date_str = date.format("%Y-%m-%d").to_string();
+            let s = sess_map.get(&date_str).copied().unwrap_or(0);
+            let m = mem_map.get(&date_str).copied().unwrap_or(0);
+            let d = dec_map.get(&date_str).copied().unwrap_or(0);
+            result.push((date_str, s, m, d));
+        }
+
+        Ok(result)
+    }
+
+    /// Returns sessions from today and yesterday for briefing comparison.
+    pub fn get_recent_sessions_for_briefing(&self) -> Result<Vec<Session>> {
+        let conn = self.conn.lock().expect("lock poisoned");
+
+        let now = Utc::now().naive_utc();
+        let cutoff = (now - chrono::Duration::days(1))
+            .date()
+            .and_hms_opt(0, 0, 0)
+            .context("invalid date")?;
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, project_id, agent, started_at, ended_at,
+                        duration_minutes, message_count, tool_call_count,
+                        total_tokens, files_changed, summary
+                 FROM sessions
+                 WHERE started_at >= ?
+                 ORDER BY started_at DESC",
+            )
+            .context("failed to prepare recent sessions for briefing")?;
+
+        let rows = stmt
+            .query_map(params![cutoff], |row| {
+                let files_str: String = row.get::<_, String>(9).unwrap_or_default();
+                Ok(Session {
+                    id: row.get(0)?,
+                    project_id: row.get(1)?,
+                    agent: row.get(2)?,
+                    started_at: row.get(3)?,
+                    ended_at: row.get(4)?,
+                    duration_minutes: row.get(5)?,
+                    message_count: row.get(6)?,
+                    tool_call_count: row.get(7)?,
+                    total_tokens: row.get(8)?,
+                    files_changed: json_to_vec(&files_str),
+                    summary: row.get(10)?,
+                })
+            })
+            .context("failed to query recent sessions for briefing")?;
+
+        let mut sessions = Vec::new();
+        for row in rows {
+            sessions.push(row.context("failed to read briefing session row")?);
+        }
+        Ok(sessions)
+    }
+
     /// Get all decisions, optionally filtered by project.
     pub fn get_decisions(&self, project: Option<&str>, limit: usize) -> Result<Vec<Decision>> {
         let conn = self.conn.lock().expect("lock poisoned");
@@ -1723,15 +2112,23 @@ impl DuckStore {
 
     /// Get all sessions for a specific project.
     pub fn get_project_sessions(&self, project_id: &str) -> Result<Vec<Session>> {
-        self.search_sessions(None, Some(project_id), None, 10_000)
+        self.search_sessions(None, Some(project_id), None, i32::MAX as usize)
     }
 
-    /// Get distinct project IDs from sessions.
+    /// Get distinct project IDs across all persisted knowledge types.
     pub fn get_project_ids(&self) -> Result<Vec<String>> {
         let conn = self.conn.lock().expect("lock poisoned");
         let mut stmt = conn
             .prepare(
-                "SELECT DISTINCT project_id FROM sessions
+                "SELECT DISTINCT project_id FROM (
+                    SELECT project_id FROM sessions
+                    UNION ALL
+                    SELECT project_id FROM memories
+                    UNION ALL
+                    SELECT project_id FROM decisions
+                    UNION ALL
+                    SELECT project_id FROM facts
+                 ) AS projects
                  WHERE project_id IS NOT NULL
                  ORDER BY project_id",
             )
@@ -1748,25 +2145,101 @@ impl DuckStore {
         Ok(ids)
     }
 
-    /// Delete a session and its related tool calls.
+    /// Delete a session and all data derived from that transcript.
+    ///
+    /// Graph cleanup is committed before relational deletion to avoid a DuckDB
+    /// foreign-key limitation around parent/child deletes in one transaction.
     pub fn delete_session(&self, session_id: &str) -> Result<bool> {
-        let conn = self.conn.lock().expect("lock poisoned");
+        let mut conn = self.conn.lock().expect("lock poisoned");
+        let stale_graph_ids: Vec<String> = {
+            let mut statement = conn
+                .prepare(
+                    "SELECT 'session:' || ? AS graph_id
+                     UNION ALL
+                     SELECT 'memory:' || id FROM memories WHERE source_session_id = ?
+                     UNION ALL
+                     SELECT 'decision:' || id FROM decisions WHERE session_id = ?",
+                )
+                .context("failed to prepare session graph lookup")?;
+            let rows = statement
+                .query_map(params![session_id, session_id, session_id], |row| {
+                    row.get::<_, String>(0)
+                })
+                .context("failed to query session graph IDs")?;
+            let mut ids = Vec::new();
+            for row in rows {
+                ids.push(row.context("failed to read session graph ID")?);
+            }
+            ids
+        };
+        for graph_id in &stale_graph_ids {
+            delete_graph_node_with_edges(&mut conn, graph_id)?;
+        }
         conn.execute(
-            "DELETE FROM tool_calls WHERE session_id = ?",
+            "DELETE FROM memory_tags WHERE memory_id IN (
+                SELECT id FROM memories WHERE source_session_id = ?
+            )",
             params![session_id],
         )
-        .context("failed to delete tool_calls for session")?;
+        .context("failed to delete session memory tags")?;
 
-        let affected = conn
+        let transaction = conn
+            .transaction()
+            .context("failed to begin session deletion transaction")?;
+        transaction
+            .execute(
+                "DELETE FROM memories WHERE source_session_id = ?",
+                params![session_id],
+            )
+            .context("failed to delete session memories")?;
+        transaction
+            .execute(
+                "DELETE FROM decisions WHERE session_id = ?",
+                params![session_id],
+            )
+            .context("failed to delete session decisions")?;
+        transaction
+            .execute(
+                "DELETE FROM facts WHERE source_session_id = ?",
+                params![session_id],
+            )
+            .context("failed to delete session facts")?;
+        transaction
+            .execute(
+                "DELETE FROM tool_calls WHERE session_id = ?",
+                params![session_id],
+            )
+            .context("failed to delete session tool calls")?;
+        let affected = transaction
             .execute("DELETE FROM sessions WHERE id = ?", params![session_id])
             .context("failed to delete session")?;
-
+        transaction
+            .commit()
+            .context("failed to commit session deletion transaction")?;
         Ok(affected > 0)
     }
-
     /// Delete old sessions before a given date. Returns number deleted.
     pub fn gc_sessions_before(&self, before: NaiveDateTime) -> Result<usize> {
         let conn = self.conn.lock().expect("lock poisoned");
+
+        // Graph session nodes are derived from sessions and must not survive
+        // retention cleanup.
+        conn.execute(
+            "DELETE FROM graph_edges
+             WHERE from_id IN (
+                    SELECT 'session:' || id FROM sessions WHERE started_at < ?
+                 ) OR to_id IN (
+                    SELECT 'session:' || id FROM sessions WHERE started_at < ?
+                 )",
+            params![before, before],
+        )
+        .context("failed to delete graph edges for old sessions")?;
+        conn.execute(
+            "DELETE FROM graph_nodes
+             WHERE id IN (SELECT 'session:' || id FROM sessions WHERE started_at < ?)",
+            params![before],
+        )
+        .context("failed to delete graph nodes for old sessions")?;
 
         // First delete tool_calls for those sessions
         conn.execute(
@@ -1784,8 +2257,30 @@ impl DuckStore {
         Ok(affected)
     }
 
+    /// Delete tool calls whose session no longer exists.
+    pub fn delete_orphaned_tool_calls(&self) -> Result<usize> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let affected = conn
+            .execute(
+                "DELETE FROM tool_calls
+                 WHERE session_id IS NOT NULL
+                   AND session_id NOT IN (SELECT id FROM sessions)",
+                [],
+            )
+            .context("failed to delete orphaned tool_calls")?;
+        Ok(affected)
+    }
+
     /// Insert a note as a memory.
     pub fn insert_note(&self, content: &str, project: Option<&str>) -> Result<String> {
+        let content = content.trim();
+        if content.is_empty() {
+            anyhow::bail!("note content cannot be empty");
+        }
+        let project = project.and_then(|project| {
+            let trimmed = project.trim();
+            (!trimmed.is_empty()).then_some(trimmed)
+        });
         let id = uuid::Uuid::new_v4().to_string();
         let now = Utc::now().naive_utc();
         let memory = Memory {
@@ -1802,6 +2297,93 @@ impl DuckStore {
         };
         self.insert_memory(&memory)?;
         Ok(id)
+    }
+
+    /// Insert a manual note and associate normalized tags with it.
+    pub fn insert_note_with_tags(
+        &self,
+        content: &str,
+        project: Option<&str>,
+        tags: &[String],
+    ) -> Result<String> {
+        let normalized = normalize_tags(tags)?;
+        let id = self.insert_note(content, project)?;
+        self.set_memory_tags(&id, &normalized)?;
+        Ok(id)
+    }
+
+    /// Replace all tags for a memory.
+    pub fn set_memory_tags(&self, memory_id: &str, tags: &[String]) -> Result<()> {
+        let normalized = normalize_tags(tags)?;
+        let conn = self.conn.lock().expect("lock poisoned");
+        conn.execute(
+            "DELETE FROM memory_tags WHERE memory_id = ?",
+            params![memory_id],
+        )
+        .context("failed to clear memory tags")?;
+
+        let mut stmt = conn
+            .prepare("INSERT INTO memory_tags (memory_id, tag) VALUES (?, ?)")
+            .context("failed to prepare memory tag insert")?;
+        for tag in &normalized {
+            stmt.execute(params![memory_id, tag])
+                .context("failed to insert memory tags")?;
+        }
+        Ok(())
+    }
+
+    /// Return tags for a memory in stable alphabetical order.
+    pub fn get_memory_tags(&self, memory_id: &str) -> Result<Vec<String>> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let mut stmt = conn
+            .prepare("SELECT tag FROM memory_tags WHERE memory_id = ? ORDER BY tag")
+            .context("failed to prepare memory tag lookup")?;
+        let rows = stmt
+            .query_map(params![memory_id], |row| row.get::<_, String>(0))
+            .context("failed to query memory tags")?;
+        let mut tags = Vec::new();
+        for row in rows {
+            tags.push(row.context("failed to read memory tag")?);
+        }
+        Ok(tags)
+    }
+
+    /// Find memories by exact (case-insensitive) tag.
+    pub fn search_memories_by_tag(&self, tag: &str, limit: usize) -> Result<Vec<Memory>> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let mut stmt = conn
+            .prepare(
+                "SELECT m.id, m.project_id, m.content, m.memory_type,
+                        m.source_session_id, m.confidence, m.access_count,
+                        m.created_at, m.updated_at, m.valid_until
+                 FROM memories m
+                 JOIN memory_tags t ON t.memory_id = m.id
+                 WHERE lower(t.tag) = lower(?)
+                 ORDER BY m.created_at DESC NULLS LAST
+                 LIMIT ?",
+            )
+            .context("failed to prepare tag search")?;
+        let rows = stmt
+            .query_map(params![tag, limit as i64], |row| {
+                Ok(Memory {
+                    id: row.get(0)?,
+                    project_id: row.get(1)?,
+                    content: row.get(2)?,
+                    memory_type: row.get(3)?,
+                    source_session_id: row.get(4)?,
+                    confidence: row.get::<_, f32>(5).unwrap_or(1.0),
+                    access_count: row.get::<_, i32>(6).unwrap_or(0),
+                    created_at: row.get(7)?,
+                    updated_at: row.get(8)?,
+                    valid_until: row.get(9)?,
+                })
+            })
+            .context("failed to query memories by tag")?;
+        let mut memories = Vec::new();
+        for row in rows {
+            memories.push(row.context("failed to read tagged memory")?);
+        }
+        Ok(memories)
     }
 
     /// Get per-agent session counts.
@@ -2281,6 +2863,30 @@ impl DuckStore {
         }
     }
 
+    /// List all graph nodes in stable ID order.
+    pub fn list_graph_nodes(&self) -> Result<Vec<GraphNodeRow>> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let mut stmt = conn
+            .prepare("SELECT id, kind, name, properties FROM graph_nodes ORDER BY id")
+            .context("failed to prepare graph node list")?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(GraphNodeRow {
+                    id: row.get(0)?,
+                    kind: row.get(1)?,
+                    name: row.get(2)?,
+                    properties: row.get::<_, String>(3).unwrap_or_else(|_| "{}".to_string()),
+                })
+            })
+            .context("failed to query graph nodes")?;
+
+        let mut nodes = Vec::new();
+        for row in rows {
+            nodes.push(row.context("failed to read graph node row")?);
+        }
+        Ok(nodes)
+    }
+
     /// Delete a graph node and all its incident edges. Returns `true` if the
     /// node existed.
     pub fn delete_graph_node(&self, id: &str) -> Result<bool> {
@@ -2393,22 +2999,35 @@ impl DuckStore {
     }
 
     // -----------------------------------------------------------------------
-    // Graph PGQ queries (require DuckPGQ extension)
+    // Graph algorithms (persisted SQL tables; DuckPGQ is optional)
     // -----------------------------------------------------------------------
 
+    fn load_graph_edges(&self) -> Result<Vec<(String, String, String)>> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let mut stmt = conn
+            .prepare("SELECT from_id, to_id, kind FROM graph_edges")
+            .context("failed to prepare graph edge load")?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })
+            .context("failed to load graph edges")?;
+
+        let mut edges = Vec::new();
+        for row in rows {
+            edges.push(row.context("failed to read graph edge")?);
+        }
+        Ok(edges)
+    }
+
     /// Find the shortest path between two nodes (up to `max_depth` hops).
-    /// Returns the sequence of node IDs along the path, or an empty vec if no
-    /// path exists. Requires the DuckPGQ extension to be loaded via
-    /// `init_graph()`.
-    ///
-    /// DuckPGQ SQL/PGQ syntax (intended):
-    /// ```sql
-    /// SELECT path_nodes
-    /// FROM GRAPH_TABLE(remembrant_graph
-    ///     MATCH p = ANY SHORTEST (a:node WHERE a.id = ?)-[e:edge]->{1,N}(b:node WHERE b.id = ?)
-    ///     COLUMNS (path_nodes(p))
-    /// )
-    /// ```
+    /// Returns the sequence of node IDs along the path, or an empty vector if
+    /// no path exists. The implementation uses the persisted graph tables and
+    /// does not require the optional DuckPGQ extension.
     pub fn pgq_shortest_path(
         &self,
         from_id: &str,
@@ -2419,81 +3038,133 @@ impl DuckStore {
             return Ok(vec![from_id.to_string()]);
         }
 
-        let conn = self.conn.lock().expect("lock poisoned");
-
-        // DuckPGQ shortest path query.
-        // The exact syntax may vary across DuckPGQ versions; if this fails the
-        // caller gets a descriptive error.
-        let sql = format!(
-            "FROM GRAPH_TABLE(remembrant_graph
-                 MATCH p = ANY SHORTEST (a:graph_nodes WHERE a.id = ?)-[e:graph_edges]->{{1,{max_depth}}}(b:graph_nodes WHERE b.id = ?)
-                 COLUMNS (vertices(p) AS path_vertices)
-             )"
-        );
-
-        let result = conn.query_row(&sql, params![from_id, to_id], |row| {
-            // DuckPGQ returns path vertices as a LIST; extract as a string
-            // representation and parse, or read directly if the driver supports
-            // list types.
-            let raw: String = row.get(0)?;
-            Ok(raw)
-        });
-
-        match result {
-            Ok(raw) => {
-                // Parse the returned list representation.  DuckPGQ returns
-                // something like `[{id: a, ...}, {id: b, ...}]` — extract IDs.
-                let ids: Vec<String> = raw
-                    .split("id: ")
-                    .skip(1)
-                    .filter_map(|s| s.split([',', '}'].as_ref()).next())
-                    .map(|s| s.trim().to_string())
-                    .collect();
-                Ok(ids)
-            }
-            Err(duckdb::Error::QueryReturnedNoRows) => Ok(Vec::new()),
-            Err(e) => Err(anyhow::Error::new(e)
-                .context("DuckPGQ shortest_path query failed — ensure init_graph() was called")),
+        let edges = self.load_graph_edges()?;
+        let mut adjacency: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        for (from, to, _) in edges {
+            adjacency.entry(from).or_default().push(to);
         }
+
+        let mut parents: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        let mut depths: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+        depths.insert(from_id.to_string(), 0);
+        let mut frontier = vec![from_id.to_string()];
+
+        while let Some(current) = frontier.first().cloned() {
+            frontier.remove(0);
+            let Some(next_depth) = depths
+                .get(&current)
+                .map(|depth| depth + 1)
+                .filter(|depth| *depth <= max_depth)
+            else {
+                continue;
+            };
+
+            for neighbor in adjacency.get(&current).cloned().unwrap_or_default() {
+                if parents.contains_key(&neighbor) || neighbor == from_id {
+                    continue;
+                }
+                parents.insert(neighbor.clone(), current.clone());
+                depths.insert(neighbor.clone(), next_depth);
+                if neighbor == to_id {
+                    let mut path = vec![to_id.to_string()];
+                    while let Some(parent) = parents.get(path.last().expect("path exists")) {
+                        path.push(parent.clone());
+                        if parent == from_id {
+                            path.reverse();
+                            return Ok(path);
+                        }
+                    }
+                }
+                frontier.push(neighbor);
+            }
+        }
+
+        Ok(Vec::new())
     }
 
     /// Run PageRank on the graph and return the top `limit` nodes with scores.
-    /// Requires the DuckPGQ extension to be loaded via `init_graph()`.
-    ///
-    /// DuckPGQ syntax (intended):
-    /// ```sql
-    /// SELECT node_id, pagerank_score
-    /// FROM pagerank(remembrant_graph, graph_nodes, graph_edges)
-    /// ORDER BY pagerank_score DESC LIMIT ?
-    /// ```
+    /// This deterministic implementation works directly on the persisted graph
+    /// tables and does not require the optional DuckPGQ extension.
     pub fn pgq_pagerank(&self, limit: usize) -> Result<Vec<(String, f64)>> {
-        let conn = self.conn.lock().expect("lock poisoned");
+        let edges = self.load_graph_edges()?;
+        let mut nodes: Vec<String> = Vec::new();
+        let mut node_set = std::collections::HashSet::new();
+        let mut outgoing: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
 
-        let mut stmt = conn
-            .prepare(
-                "SELECT node_id, pagerank_score
-                 FROM pagerank(remembrant_graph, graph_nodes, graph_edges)
-                 ORDER BY pagerank_score DESC
-                 LIMIT ?",
-            )
-            .context("DuckPGQ pagerank query failed — ensure init_graph() was called")?;
-
-        let rows = stmt
-            .query_map(params![limit as i64], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
-            })
-            .context("failed to execute pagerank query")?;
-
-        let mut results = Vec::new();
-        for row in rows {
-            results.push(row.context("failed to read pagerank row")?);
+        for (from, to, _) in edges {
+            if node_set.insert(from.clone()) {
+                nodes.push(from.clone());
+            }
+            if node_set.insert(to.clone()) {
+                nodes.push(to.clone());
+            }
+            outgoing.entry(from).or_default().push(to);
         }
-        Ok(results)
+        if nodes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let node_count = nodes.len() as f64;
+        let damping = 0.85;
+        let mut scores: std::collections::HashMap<String, f64> = nodes
+            .iter()
+            .map(|node| (node.clone(), 1.0 / node_count))
+            .collect();
+        let mut incoming: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        for (from, targets) in &outgoing {
+            for target in targets {
+                incoming
+                    .entry(target.clone())
+                    .or_default()
+                    .push(from.clone());
+            }
+        }
+
+        for _ in 0..20 {
+            let mut next = std::collections::HashMap::new();
+            let dangling_sum: f64 = nodes
+                .iter()
+                .filter(|node| outgoing.get(*node).is_none_or(Vec::is_empty))
+                .map(|node| scores[node])
+                .sum();
+
+            for node in &nodes {
+                let contribution: f64 = incoming
+                    .get(node)
+                    .into_iter()
+                    .flatten()
+                    .map(|source| scores[source] / outgoing[source].len() as f64)
+                    .sum();
+                let score = (1.0 - damping) / node_count
+                    + damping * (contribution + dangling_sum / node_count);
+                next.insert(node.clone(), score);
+            }
+            scores = next;
+        }
+
+        nodes.sort_by(|a, b| {
+            scores[b]
+                .partial_cmp(&scores[a])
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.cmp(b))
+        });
+        Ok(nodes
+            .into_iter()
+            .take(limit)
+            .map(|node| {
+                let score = scores[&node];
+                (node, score)
+            })
+            .collect())
     }
 
     /// Pattern match: find all nodes connected to `node_id` via a specific
     /// edge kind in the given direction ("outgoing" or "incoming").
-    /// Requires the DuckPGQ extension to be loaded via `init_graph()`.
+    /// Uses standard SQL so graph exploration remains available in all builds.
     pub fn pgq_pattern_match(
         &self,
         node_id: &str,
@@ -2502,22 +3173,23 @@ impl DuckStore {
     ) -> Result<Vec<GraphNodeRow>> {
         let conn = self.conn.lock().expect("lock poisoned");
 
-        // Use SQL/PGQ MATCH with a WHERE filter on edge kind.
         let sql = if direction == "outgoing" {
-            "FROM GRAPH_TABLE(remembrant_graph
-                 MATCH (a:graph_nodes WHERE a.id = ?)-[e:graph_edges WHERE e.kind = ?]->(b:graph_nodes)
-                 COLUMNS (b.id, b.kind, b.name, b.properties)
-             )"
+            "SELECT n.id, n.kind, n.name, n.properties
+             FROM graph_edges e
+             JOIN graph_nodes n ON n.id = e.to_id
+             WHERE e.from_id = ? AND e.kind = ?
+             ORDER BY n.id"
         } else {
-            "FROM GRAPH_TABLE(remembrant_graph
-                 MATCH (a:graph_nodes)<-[e:graph_edges WHERE e.kind = ?]-(b:graph_nodes WHERE b.id = ?)
-                 COLUMNS (a.id, a.kind, a.name, a.properties)
-             )"
+            "SELECT n.id, n.kind, n.name, n.properties
+             FROM graph_edges e
+             JOIN graph_nodes n ON n.id = e.from_id
+             WHERE e.to_id = ? AND e.kind = ?
+             ORDER BY n.id"
         };
 
         let mut stmt = conn
             .prepare(sql)
-            .context("DuckPGQ pattern_match query failed — ensure init_graph() was called")?;
+            .context("failed to prepare graph pattern match")?;
 
         let map_row = |row: &duckdb::Row| -> duckdb::Result<GraphNodeRow> {
             Ok(GraphNodeRow {
@@ -2530,10 +3202,10 @@ impl DuckStore {
 
         let rows = if direction == "outgoing" {
             stmt.query_map(params![node_id, edge_kind], map_row)
-                .context("failed to execute pattern match")?
+                .context("failed to execute graph pattern match")?
         } else {
-            stmt.query_map(params![edge_kind, node_id], map_row)
-                .context("failed to execute pattern match")?
+            stmt.query_map(params![node_id, edge_kind], map_row)
+                .context("failed to execute graph pattern match")?
         };
 
         let mut results = Vec::new();
@@ -2759,6 +3431,390 @@ impl DuckStore {
         }
         Ok(stats)
     }
+
+    // -----------------------------------------------------------------------
+    // Briefing / daily-digest helpers
+    // -----------------------------------------------------------------------
+
+    /// Per-project breakdown for the current UTC day.
+    pub fn get_project_breakdown_today(&self) -> Result<Vec<serde_json::Value>> {
+        let now = Utc::now().naive_utc();
+        let since = now.date().and_hms_opt(0, 0, 0).context("invalid date")?;
+        let sessions = self.search_sessions(None, None, Some(since), 10_000)?;
+
+        let mut by_project: std::collections::HashMap<
+            String,
+            (usize, i64, Vec<String>, std::collections::HashSet<String>),
+        > = std::collections::HashMap::new();
+
+        for s in &sessions {
+            let project = s
+                .project_id
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string());
+            let entry = by_project
+                .entry(project)
+                .or_insert_with(|| (0, 0, Vec::new(), std::collections::HashSet::new()));
+            entry.0 += 1;
+            entry.1 += s.total_tokens.unwrap_or(0) as i64;
+            for f in &s.files_changed {
+                if !entry.2.contains(f) {
+                    entry.2.push(f.clone());
+                }
+            }
+            entry.3.insert(s.agent.clone());
+        }
+
+        let mut result: Vec<serde_json::Value> = by_project
+            .into_iter()
+            .map(|(project, (sessions, tokens, files, agents))| {
+                serde_json::json!({
+                    "project": project,
+                    "sessions": sessions,
+                    "tokens": tokens,
+                    "files_changed": files,
+                    "agents": agents.into_iter().collect::<Vec<_>>(),
+                })
+            })
+            .collect();
+        result.sort_by(|a, b| {
+            b["sessions"]
+                .as_u64()
+                .unwrap_or(0)
+                .cmp(&a["sessions"].as_u64().unwrap_or(0))
+        });
+        Ok(result)
+    }
+
+    /// Decisions created during the current UTC day.
+    pub fn get_decisions_today(&self) -> Result<Vec<serde_json::Value>> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let now = Utc::now().naive_utc();
+        let since = now.date().and_hms_opt(0, 0, 0).context("invalid date")?;
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT what, why, created_at
+                 FROM decisions
+                 WHERE created_at >= ?
+                 ORDER BY created_at DESC",
+            )
+            .context("failed to prepare get_decisions_today")?;
+
+        let rows = stmt
+            .query_map(params![since], |row| {
+                let what: String = row.get(0)?;
+                let why: Option<String> = row.get(1)?;
+                let created_at: Option<NaiveDateTime> = row.get(2)?;
+                Ok(serde_json::json!({
+                    "what": what,
+                    "why": why,
+                    "created_at": created_at.map(|t| t.to_string()),
+                }))
+            })
+            .context("failed to query decisions today")?;
+
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(row.context("failed to read decisions_today row")?);
+        }
+        Ok(result)
+    }
+
+    /// Facts created or becoming valid during the current UTC day.
+    pub fn get_new_facts_today(&self) -> Result<Vec<serde_json::Value>> {
+        let conn = self.conn.lock().expect("lock poisoned");
+        let now = Utc::now().naive_utc();
+        let since = now.date().and_hms_opt(0, 0, 0).context("invalid date")?;
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT subject, predicate, object, confidence
+                 FROM facts
+                 WHERE created_at >= ? OR valid_at >= ?
+                 ORDER BY created_at DESC NULLS LAST",
+            )
+            .context("failed to prepare get_new_facts_today")?;
+
+        let rows = stmt
+            .query_map(params![since, since], |row| {
+                let subject: String = row.get(0)?;
+                let predicate: String = row.get(1)?;
+                let object: String = row.get(2)?;
+                let confidence: f32 = row.get::<_, f32>(3).unwrap_or(0.0);
+                Ok(serde_json::json!({
+                    "subject": subject,
+                    "predicate": predicate,
+                    "object": object,
+                    "confidence": confidence,
+                }))
+            })
+            .context("failed to query new facts today")?;
+
+        let mut result = Vec::new();
+        for row in rows {
+            result.push(row.context("failed to read new_facts_today row")?);
+        }
+        Ok(result)
+    }
+
+    /// Top files changed today, aggregated from session `files_changed` arrays.
+    pub fn get_top_files_today(&self, limit: usize) -> Result<Vec<(String, i64)>> {
+        let now = Utc::now().naive_utc();
+        let since = now.date().and_hms_opt(0, 0, 0).context("invalid date")?;
+        let sessions = self.search_sessions(None, None, Some(since), 10_000)?;
+
+        let mut counts: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+        for s in &sessions {
+            for f in &s.files_changed {
+                *counts.entry(f.clone()).or_insert(0) += 1;
+            }
+        }
+
+        let mut pairs: Vec<(String, i64)> = counts.into_iter().collect();
+        pairs.sort_by(|a, b| b.1.cmp(&a.1));
+        pairs.truncate(limit);
+        Ok(pairs)
+    }
+
+    /// Session summaries from the last 24 hours.
+    pub fn get_session_summaries_today(&self) -> Result<Vec<serde_json::Value>> {
+        let now = Utc::now().naive_utc();
+        let since = now.date().and_hms_opt(0, 0, 0).context("invalid date")?;
+        let sessions = self.search_sessions(None, None, Some(since), 10_000)?;
+
+        let result: Vec<serde_json::Value> = sessions
+            .into_iter()
+            .filter(|s| s.summary.is_some())
+            .map(|s| {
+                serde_json::json!({
+                    "agent": s.agent,
+                    "project": s.project_id,
+                    "summary": s.summary,
+                    "started_at": s.started_at.map(|t| t.to_string()),
+                })
+            })
+            .collect();
+        Ok(result)
+    }
+
+    /// Return items that need human attention: stale memories, contradictory
+    /// facts, high-churn files, and cross-agent conflicts.
+    pub fn get_attention_items(&self) -> Result<Vec<serde_json::Value>> {
+        let now = Utc::now().naive_utc();
+        let stale_cutoff = now - chrono::Duration::days(30);
+        let churn_cutoff = now - chrono::Duration::days(7);
+        let conflict_cutoff = now - chrono::Duration::days(7);
+        let conn = self.conn.lock().expect("lock poisoned");
+        let mut items: Vec<serde_json::Value> = Vec::new();
+
+        // 1. Stale memories — older than 30 days
+        {
+            let mut stmt = conn.prepare(
+                "SELECT id, project_id, content, memory_type, created_at
+                 FROM memories
+                 WHERE created_at < ?
+                 ORDER BY created_at ASC
+                 LIMIT 10",
+            )?;
+            let rows = stmt.query_map(params![stale_cutoff], |row| {
+                let id: String = row.get(0)?;
+                let project_id: Option<String> = row.get(1)?;
+                let content: String = row.get(2)?;
+                let memory_type: Option<String> = row.get(3)?;
+                let created_at: Option<NaiveDateTime> = row.get(4)?;
+                Ok((id, project_id, content, memory_type, created_at))
+            })?;
+            for row in rows {
+                let (id, project_id, content, memory_type, created_at) = row?;
+                let snippet: String = content.chars().take(120).collect();
+                let title = format!(
+                    "Stale {} memory in {}",
+                    memory_type.as_deref().unwrap_or("unknown"),
+                    project_id.as_deref().unwrap_or("unknown project"),
+                );
+                let ts = created_at
+                    .map(|t| t.and_utc().to_rfc3339())
+                    .unwrap_or_default();
+                items.push(serde_json::json!({
+                    "type": "stale_memory",
+                    "severity": "low",
+                    "title": title,
+                    "detail": format!("Created {ts}, not updated in 30+ days: {snippet}..."),
+                    "entity_ids": [id],
+                    "created_at": ts,
+                }));
+            }
+        }
+
+        // 2. Contradictory facts — same subject+predicate, different object, both active
+        {
+            let mut stmt = conn.prepare(
+                "SELECT f1.id, f2.id, f1.subject, f1.predicate, f1.object, f2.object,
+                        f1.source_agent, f2.source_agent, f1.created_at
+                 FROM facts f1
+                 JOIN facts f2
+                   ON f1.subject = f2.subject
+                  AND f1.predicate = f2.predicate
+                  AND f1.id < f2.id
+                  AND f1.object <> f2.object
+                 WHERE f1.invalid_at IS NULL
+                   AND f2.invalid_at IS NULL
+                 LIMIT 10",
+            )?;
+            let rows = stmt.query_map([], |row| {
+                let id1: String = row.get(0)?;
+                let id2: String = row.get(1)?;
+                let subject: String = row.get(2)?;
+                let predicate: String = row.get(3)?;
+                let obj1: String = row.get(4)?;
+                let obj2: String = row.get(5)?;
+                let agent1: Option<String> = row.get(6)?;
+                let agent2: Option<String> = row.get(7)?;
+                let created_at: Option<NaiveDateTime> = row.get(8)?;
+                Ok((
+                    id1, id2, subject, predicate, obj1, obj2, agent1, agent2, created_at,
+                ))
+            })?;
+            for row in rows {
+                let (id1, id2, subject, predicate, obj1, obj2, agent1, agent2, created_at) = row?;
+                let a1 = agent1.as_deref().unwrap_or("unknown");
+                let a2 = agent2.as_deref().unwrap_or("unknown");
+                let ts = created_at
+                    .map(|t| t.and_utc().to_rfc3339())
+                    .unwrap_or_default();
+                items.push(serde_json::json!({
+                    "type": "contradictory_fact",
+                    "severity": "high",
+                    "title": format!("Contradictory facts for \"{subject}\""),
+                    "detail": format!("{subject} {predicate} \"{obj1}\" ({a1}) vs \"{obj2}\" ({a2})"),
+                    "entity_ids": [id1, id2],
+                    "created_at": ts,
+                }));
+            }
+        }
+
+        // 3. High-churn files — >5 sessions in last 7 days
+        {
+            let result: Result<(), anyhow::Error> = (|| {
+                let mut stmt = conn.prepare(
+                    "SELECT f.file, COUNT(*) AS freq
+                     FROM sessions s,
+                          LATERAL (
+                              SELECT UNNEST(
+                              json_extract_string(s.files_changed, '$[*]')
+                              ) AS file
+                          ) f
+                     WHERE s.started_at >= ?
+                       AND s.files_changed IS NOT NULL
+                       AND s.files_changed <> '[]'
+                       AND s.files_changed <> ''
+                     GROUP BY f.file
+                     HAVING COUNT(*) > 5
+                     ORDER BY freq DESC
+                     LIMIT 10",
+                )?;
+                let rows = stmt.query_map(params![churn_cutoff], |row| {
+                    let file_path: String = row.get(0)?;
+                    let freq: i64 = row.get(1)?;
+                    Ok((file_path, freq))
+                })?;
+                for row in rows {
+                    let (file_path, freq) = row?;
+                    items.push(serde_json::json!({
+                        "type": "high_churn",
+                        "severity": "medium",
+                        "title": format!("High-churn file: {file_path}"),
+                        "detail": format!("{file_path} changed in {freq} sessions in the last 7 days"),
+                        "entity_ids": [file_path],
+                        "created_at": Utc::now().to_rfc3339(),
+                    }));
+                }
+                Ok(())
+            })();
+            if let Err(e) = result {
+                warn!("high-churn query failed: {e}");
+            }
+        }
+
+        // 4. Cross-agent conflicts — different agents, same project+type, different content
+        {
+            let result: Result<(), anyhow::Error> = (|| {
+                let mut stmt = conn.prepare(
+                    "SELECT m1.id, m2.id, m1.project_id, m1.memory_type,
+                            s1.agent, s2.agent, m1.content, m2.content, m1.created_at
+                     FROM memories m1
+                     JOIN memories m2
+                       ON m1.project_id = m2.project_id
+                      AND m1.memory_type = m2.memory_type
+                      AND m1.id < m2.id
+                      AND m1.content <> m2.content
+                     JOIN sessions s1 ON m1.source_session_id = s1.id
+                     JOIN sessions s2 ON m2.source_session_id = s2.id
+                     WHERE s1.agent <> s2.agent
+                       AND m1.created_at >= ?
+                       AND m2.created_at >= ?
+                     LIMIT 10",
+                )?;
+                let rows = stmt.query_map(params![conflict_cutoff, conflict_cutoff], |row| {
+                    let id1: String = row.get(0)?;
+                    let id2: String = row.get(1)?;
+                    let project_id: Option<String> = row.get(2)?;
+                    let memory_type: Option<String> = row.get(3)?;
+                    let agent1: String = row.get(4)?;
+                    let agent2: String = row.get(5)?;
+                    let content1: String = row.get(6)?;
+                    let content2: String = row.get(7)?;
+                    let created_at: Option<NaiveDateTime> = row.get(8)?;
+                    Ok((
+                        id1,
+                        id2,
+                        project_id,
+                        memory_type,
+                        agent1,
+                        agent2,
+                        content1,
+                        content2,
+                        created_at,
+                    ))
+                })?;
+                for row in rows {
+                    let (
+                        id1,
+                        id2,
+                        project_id,
+                        memory_type,
+                        agent1,
+                        agent2,
+                        content1,
+                        content2,
+                        created_at,
+                    ) = row?;
+                    let proj = project_id.as_deref().unwrap_or("unknown");
+                    let mtype = memory_type.as_deref().unwrap_or("unknown");
+                    let snip1: String = content1.chars().take(80).collect();
+                    let snip2: String = content2.chars().take(80).collect();
+                    let ts = created_at
+                        .map(|t| t.and_utc().to_rfc3339())
+                        .unwrap_or_default();
+                    items.push(serde_json::json!({
+                        "type": "conflict",
+                        "severity": "high",
+                        "title": format!("Cross-agent conflict in {proj} ({mtype})"),
+                        "detail": format!("{agent1}: \"{snip1}...\" vs {agent2}: \"{snip2}...\""),
+                        "entity_ids": [id1, id2],
+                        "created_at": ts,
+                    }));
+                }
+                Ok(())
+            })();
+            if let Err(e) = result {
+                warn!("cross-agent conflict query failed: {e}");
+            }
+        }
+
+        Ok(items)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2816,6 +3872,205 @@ mod tests {
         assert_eq!(recent.len(), 2);
         assert!(recent.iter().any(|s| s.id == "s-1"));
         assert!(recent.iter().any(|s| s.id == "s-2"));
+        assert_eq!(
+            store.get_session("s-1").unwrap().map(|s| s.id),
+            Some("s-1".into())
+        );
+        assert!(store.get_session("missing").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_session_replacement_is_idempotent_for_derived_rows() {
+        let store = DuckStore::open_in_memory().unwrap();
+        let session = make_session("replace-session");
+        store.insert_or_replace_session(&session).unwrap();
+
+        store
+            .insert_tool_call(&ToolCall {
+                id: "old-tool".into(),
+                session_id: Some("replace-session".into()),
+                tool_name: Some("Read".into()),
+                command: None,
+                success: None,
+                error_message: None,
+                duration_ms: None,
+                timestamp: None,
+            })
+            .unwrap();
+        let mut derived = make_memory("old-memory", "old derived memory");
+        derived.source_session_id = Some("replace-session".into());
+        store.insert_memory(&derived).unwrap();
+        store
+            .set_memory_tags("old-memory", &["derived".into()])
+            .unwrap();
+        store
+            .insert_graph_node(
+                "session:replace-session",
+                "Session",
+                "replace-session",
+                "{}",
+            )
+            .unwrap();
+        store
+            .insert_graph_node("memory:old-memory", "Memory", "old memory", "{}")
+            .unwrap();
+        store
+            .insert_graph_edge(
+                "memory:old-memory",
+                "session:replace-session",
+                "DERIVED_FROM",
+                "{}",
+            )
+            .unwrap();
+
+        let mut replacement = make_session("replace-session");
+        replacement.summary = Some("updated summary".into());
+        store.insert_or_replace_session(&replacement).unwrap();
+        store
+            .insert_tool_call(&ToolCall {
+                id: "new-tool".into(),
+                session_id: Some("replace-session".into()),
+                tool_name: Some("Edit".into()),
+                command: None,
+                success: None,
+                error_message: None,
+                duration_ms: None,
+                timestamp: None,
+            })
+            .unwrap();
+
+        assert_eq!(store.count_sessions().unwrap(), 1);
+        assert_eq!(store.count_tool_calls().unwrap(), 1);
+        assert_eq!(store.count_memories().unwrap(), 0);
+        assert!(
+            store
+                .get_graph_node("session:replace-session")
+                .unwrap()
+                .is_none()
+        );
+        assert!(store.get_graph_node("memory:old-memory").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_delete_session_cascades_all_derived_data() {
+        let store = DuckStore::open_in_memory().unwrap();
+        store
+            .insert_or_replace_session(&make_session("delete-session"))
+            .unwrap();
+        let mut memory = make_memory("delete-memory", "derived memory");
+        memory.source_session_id = Some("delete-session".into());
+        store.insert_memory(&memory).unwrap();
+        store
+            .insert_decision(&Decision {
+                id: "delete-decision".into(),
+                session_id: Some("delete-session".into()),
+                project_id: Some("proj-1".into()),
+                decision_type: None,
+                what: "delete me".into(),
+                why: None,
+                alternatives: Vec::new(),
+                outcome: None,
+                created_at: None,
+                valid_until: None,
+            })
+            .unwrap();
+        let mut fact = make_fact("delete-fact", "session", "produced", "fact");
+        fact.source_session_id = Some("delete-session".into());
+        store.insert_fact(&fact).unwrap();
+        store
+            .insert_graph_node("session:delete-session", "Session", "session", "{}")
+            .unwrap();
+
+        assert!(store.delete_session("delete-session").unwrap());
+        assert_eq!(store.count_sessions().unwrap(), 0);
+        assert_eq!(store.count_memories().unwrap(), 0);
+        assert_eq!(store.count_decisions().unwrap(), 0);
+        assert_eq!(store.count_tool_calls().unwrap(), 0);
+        assert_eq!(store.count_facts().unwrap(), 0);
+        assert!(
+            store
+                .get_graph_node("session:delete-session")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_gc_removes_old_session_graph_and_orphaned_tool_calls() {
+        let store = DuckStore::open_in_memory().unwrap();
+        let now = Utc::now().naive_utc();
+        let mut old = make_session("old-session");
+        old.started_at = Some(now - chrono::Duration::days(40));
+        let current = make_session("current-session");
+        store.insert_session(&old).unwrap();
+        store.insert_session(&current).unwrap();
+
+        store
+            .insert_graph_node("session:old-session", "Session", "old-session", "{}")
+            .unwrap();
+        store
+            .insert_graph_node(
+                "session:current-session",
+                "Session",
+                "current-session",
+                "{}",
+            )
+            .unwrap();
+        store
+            .insert_graph_edge(
+                "session:old-session",
+                "session:current-session",
+                "RELATES_TO",
+                "{}",
+            )
+            .unwrap();
+
+        store
+            .insert_tool_call(&ToolCall {
+                id: "orphan-tool".into(),
+                session_id: Some("missing-session".into()),
+                tool_name: Some("Read".into()),
+                command: None,
+                success: None,
+                error_message: None,
+                duration_ms: None,
+                timestamp: None,
+            })
+            .unwrap();
+        store
+            .insert_tool_call(&ToolCall {
+                id: "current-tool".into(),
+                session_id: Some("current-session".into()),
+                tool_name: Some("Edit".into()),
+                command: None,
+                success: None,
+                error_message: None,
+                duration_ms: None,
+                timestamp: None,
+            })
+            .unwrap();
+
+        assert_eq!(
+            store
+                .gc_sessions_before(now - chrono::Duration::days(30))
+                .unwrap(),
+            1
+        );
+        assert_eq!(store.delete_orphaned_tool_calls().unwrap(), 1);
+        assert!(
+            store
+                .get_graph_node("session:old-session")
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            store
+                .get_graph_node("session:current-session")
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(store.count_graph_edges().unwrap(), 0);
+        assert_eq!(store.count_tool_calls().unwrap(), 1);
     }
 
     #[test]
@@ -2867,6 +4122,178 @@ mod tests {
         }
         let limited = store.get_recent_sessions(3).unwrap();
         assert_eq!(limited.len(), 3);
+    }
+
+    #[test]
+    fn test_daily_and_today_analytics_use_utc_day_boundaries() {
+        let store = DuckStore::open_in_memory().unwrap();
+        let now = Utc::now().naive_utc();
+        let today_start = now.date().and_hms_opt(0, 0, 0).unwrap();
+
+        let mut current = make_session("analytics-today");
+        current.started_at = Some(now);
+        current.files_changed = vec!["src/today.rs".into()];
+
+        let mut previous = make_session("analytics-previous");
+        previous.started_at = Some(today_start - chrono::Duration::hours(1));
+        previous.files_changed = vec!["src/yesterday.rs".into()];
+
+        store.insert_session(&current).unwrap();
+        store.insert_session(&previous).unwrap();
+        store
+            .insert_memory(&make_memory("analytics-memory", "today memory"))
+            .unwrap();
+        store
+            .insert_decision(&Decision {
+                id: "analytics-decision".into(),
+                session_id: Some("analytics-today".into()),
+                project_id: Some("proj-1".into()),
+                decision_type: Some("architecture".into()),
+                what: "use UTC boundaries".into(),
+                why: None,
+                alternatives: Vec::new(),
+                outcome: None,
+                created_at: Some(now),
+                valid_until: None,
+            })
+            .unwrap();
+
+        assert_eq!(store.count_sessions_since(today_start).unwrap(), 1);
+        let todays_sessions = store.get_todays_sessions().unwrap();
+        assert_eq!(todays_sessions.len(), 1);
+        assert_eq!(todays_sessions[0].id, "analytics-today");
+        assert_eq!(
+            store
+                .get_daily_session_counts(0)
+                .unwrap()
+                .last()
+                .copied()
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            store
+                .get_daily_memory_counts(0)
+                .unwrap()
+                .last()
+                .copied()
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            store
+                .get_daily_decision_counts(0)
+                .unwrap()
+                .last()
+                .copied()
+                .unwrap(),
+            1
+        );
+
+        let daily = store.get_daily_counts(0).unwrap();
+        assert_eq!(daily.len(), 1);
+        assert_eq!(daily[0].0, now.date().to_string());
+        assert_eq!(daily[0].1, 1);
+
+        let projects = store.get_project_breakdown_today().unwrap();
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0]["sessions"].as_u64(), Some(1));
+        assert_eq!(
+            projects[0]["files_changed"][0].as_str(),
+            Some("src/today.rs")
+        );
+
+        let top_files = store.get_top_files_today(10).unwrap();
+        assert_eq!(top_files, vec![("src/today.rs".into(), 1)]);
+
+        let decisions = store.get_decisions_today().unwrap();
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0]["what"].as_str(), Some("use UTC boundaries"));
+
+        let summaries = store.get_session_summaries_today().unwrap();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0]["summary"].as_str(), Some("refactored module"));
+    }
+
+    #[test]
+    fn test_manual_notes_support_tags() {
+        let store = DuckStore::open_in_memory().unwrap();
+        let id = store
+            .insert_note_with_tags(
+                "Prefer small composable parsers",
+                Some("proj-1"),
+                &[" rust ".into(), "RUST".into(), "architecture".into()],
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.get_memory_tags(&id).unwrap(),
+            vec!["architecture".to_string(), "rust".to_string()]
+        );
+
+        let tagged = store.search_memories_by_tag("RUST", 10).unwrap();
+        assert_eq!(tagged.len(), 1);
+        assert_eq!(tagged[0].id, id);
+        assert_eq!(tagged[0].memory_type.as_deref(), Some("note"));
+        assert_eq!(tagged[0].content, "Prefer small composable parsers");
+        assert_eq!(tagged[0].project_id.as_deref(), Some("proj-1"));
+
+        let empty = store
+            .insert_note_with_tags("   ", Some("  "), &[])
+            .unwrap_err();
+        assert!(empty.to_string().contains("cannot be empty"));
+        assert_eq!(store.get_project_ids().unwrap(), vec!["proj-1".to_string()]);
+        store
+            .insert_graph_node(&format!("memory:{id}"), "Memory", "note", "{}")
+            .unwrap();
+        store
+            .insert_graph_node("project:proj-1", "Project", "proj-1", "{}")
+            .unwrap();
+        store
+            .insert_graph_edge(&format!("memory:{id}"), "project:proj-1", "ABOUT", "{}")
+            .unwrap();
+
+        assert!(store.delete_memory(&id).unwrap());
+        assert!(store.get_memory_tags(&id).unwrap().is_empty());
+        assert!(store.search_memories_by_tag("rust", 10).unwrap().is_empty());
+        assert!(
+            store
+                .get_graph_node(&format!("memory:{id}"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_attention_items_include_conflicts_and_high_churn() {
+        let store = DuckStore::open_in_memory().unwrap();
+
+        for i in 0..6 {
+            let mut session = make_session(&format!("churn-{i}"));
+            session.files_changed = vec!["src/hot.rs".into()];
+            store.insert_session(&session).unwrap();
+        }
+
+        store
+            .insert_fact(&make_fact("attention-jwt", "auth", "uses", "JWT"))
+            .unwrap();
+        store
+            .insert_fact(&make_fact("attention-oauth", "auth", "uses", "OAuth2"))
+            .unwrap();
+
+        let items = store.get_attention_items().unwrap();
+        let types: Vec<_> = items
+            .iter()
+            .filter_map(|item| item["type"].as_str())
+            .collect();
+
+        assert!(types.contains(&"high_churn"), "items: {items:?}");
+        assert!(types.contains(&"contradictory_fact"), "items: {items:?}");
+        let churn = items
+            .iter()
+            .find(|item| item["type"] == "high_churn")
+            .unwrap();
+        assert_eq!(churn["entity_ids"][0].as_str(), Some("src/hot.rs"));
     }
 
     // -------------------------------------------------------------------
@@ -3035,6 +4462,53 @@ mod tests {
 
         assert_eq!(store.count_graph_nodes().unwrap(), 0);
         assert_eq!(store.count_graph_edges().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_graph_algorithms_work_without_optional_duckpgq_extension() {
+        let store = DuckStore::open_in_memory().unwrap();
+        store.insert_graph_node("a", "Concept", "a", "{}").unwrap();
+        store.insert_graph_node("b", "Concept", "b", "{}").unwrap();
+        store.insert_graph_node("c", "Concept", "c", "{}").unwrap();
+        store
+            .insert_graph_edge("a", "b", "RELATES_TO", "{}")
+            .unwrap();
+        store
+            .insert_graph_edge("b", "c", "RELATES_TO", "{}")
+            .unwrap();
+
+        assert_eq!(
+            store.pgq_shortest_path("a", "c", 3).unwrap(),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+        assert!(store.pgq_shortest_path("c", "a", 3).unwrap().is_empty());
+        assert_eq!(store.pgq_shortest_path("a", "a", 0).unwrap(), vec!["a"]);
+
+        let pagerank = store.pgq_pagerank(3).unwrap();
+        assert_eq!(pagerank.len(), 3);
+        assert!(pagerank[0].0 == *"c" || pagerank[0].0 == *"b");
+        assert!(pagerank.iter().all(|(_, score)| score.is_finite()));
+
+        let outgoing = store
+            .pgq_pattern_match("a", "RELATES_TO", "outgoing")
+            .unwrap();
+        assert_eq!(
+            outgoing
+                .iter()
+                .map(|node| node.id.as_str())
+                .collect::<Vec<_>>(),
+            ["b"]
+        );
+        let incoming = store
+            .pgq_pattern_match("c", "RELATES_TO", "incoming")
+            .unwrap();
+        assert_eq!(
+            incoming
+                .iter()
+                .map(|node| node.id.as_str())
+                .collect::<Vec<_>>(),
+            ["b"]
+        );
     }
 
     // -------------------------------------------------------------------

--- a/engine/src/store/lance.rs
+++ b/engine/src/store/lance.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use arrow_array::types::Float32Type;
-use arrow_array::{Array, FixedSizeListArray, Float32Array, RecordBatch, StringArray, UInt32Array};
+use arrow_array::{
+    Array, FixedSizeListArray, Float32Array, RecordBatch, RecordBatchIterator, StringArray,
+    UInt32Array,
+};
 use arrow_schema::{DataType, Field, Schema};
 use futures::TryStreamExt;
 use lancedb::database::CreateTableMode;
@@ -232,13 +235,75 @@ impl LanceStore {
             .await
             .context("failed to open code_embeddings table")?;
 
-        table
-            .add(vec![batch])
-            .execute()
+        let mut upsert = table.merge_insert(&["id"]);
+        upsert
+            .when_matched_update_all(None)
+            .when_not_matched_insert_all();
+        upsert
+            .execute(Box::new(RecordBatchIterator::new(
+                vec![Ok(batch)],
+                schema.clone(),
+            )))
             .await
-            .context("failed to insert code embedding")?;
+            .context("failed to upsert code embedding")?;
 
         Ok(())
+    }
+
+    /// Delete all code embeddings for a project.
+    ///
+    /// Used by `rem embed --update` to replace stale chunks while preserving
+    /// embeddings belonging to other projects.
+    pub async fn delete_code_embeddings_for_project(&self, project_id: &str) -> Result<()> {
+        let table = self
+            .conn
+            .open_table("code_embeddings")
+            .execute()
+            .await
+            .context("failed to open code_embeddings for delete")?;
+        let escaped_project = project_id.replace('\'', "''");
+        table
+            .delete(&format!("project_id = '{escaped_project}'"))
+            .await
+            .context("failed to delete project code embeddings")?;
+        Ok(())
+    }
+
+    /// Return all code embedding IDs belonging to a project.
+    pub async fn get_code_embedding_ids_for_project(
+        &self,
+        project_id: &str,
+    ) -> Result<Vec<String>> {
+        let table = self
+            .conn
+            .open_table("code_embeddings")
+            .execute()
+            .await
+            .context("failed to open code_embeddings for ID lookup")?;
+        let escaped_project = project_id.replace('\'', "''");
+        let batches = table
+            .query()
+            .only_if(format!("project_id = '{escaped_project}'"))
+            .execute()
+            .await
+            .context("failed to query project code embedding IDs")?
+            .try_collect::<Vec<_>>()
+            .await
+            .context("failed to collect project code embedding IDs")?;
+
+        let mut ids = Vec::new();
+        for batch in &batches {
+            let Some(id_array) = batch
+                .column_by_name("id")
+                .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+            else {
+                continue;
+            };
+            ids.extend(id_array.iter().flatten().map(str::to_string));
+        }
+        ids.sort();
+        ids.dedup();
+        Ok(ids)
     }
 
     /// Insert a single memory embedding record.
@@ -279,11 +344,17 @@ impl LanceStore {
             .await
             .context("failed to open memory_embeddings table")?;
 
-        table
-            .add(vec![batch])
-            .execute()
+        let mut upsert = table.merge_insert(&["id"]);
+        upsert
+            .when_matched_update_all(None)
+            .when_not_matched_insert_all();
+        upsert
+            .execute(Box::new(RecordBatchIterator::new(
+                vec![Ok(batch)],
+                schema.clone(),
+            )))
             .await
-            .context("failed to insert memory embedding")?;
+            .context("failed to upsert memory embedding")?;
 
         Ok(())
     }
@@ -660,5 +731,124 @@ impl LanceStore {
         }
 
         Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn embedding_inserts_are_idempotent_by_id() {
+        let directory = tempfile::tempdir().expect("temporary LanceDB directory");
+        let store = LanceStore::open_with_dim(directory.path(), 4)
+            .await
+            .expect("open LanceDB");
+
+        store
+            .insert_code_embedding(
+                "stable-code",
+                &[1.0, 0.0, 0.0, 0.0],
+                "old code",
+                "function",
+                "project",
+                Some("src/a.rs"),
+                Some("rust"),
+            )
+            .await
+            .expect("first code insert");
+        store
+            .insert_code_embedding(
+                "stable-code",
+                &[1.0, 0.0, 0.0, 0.0],
+                "new code",
+                "function",
+                "project",
+                Some("src/a.rs"),
+                Some("rust"),
+            )
+            .await
+            .expect("code upsert");
+
+        let code = store
+            .search_code(&[1.0, 0.0, 0.0, 0.0], 10)
+            .await
+            .expect("search code");
+        assert_eq!(code.len(), 1);
+        assert_eq!(code[0].content, "new code");
+
+        store
+            .insert_memory_embedding(
+                "stable-memory",
+                &[0.0, 1.0, 0.0, 0.0],
+                "old memory",
+                "note",
+                "project",
+            )
+            .await
+            .expect("first memory insert");
+        store
+            .insert_memory_embedding(
+                "stable-memory",
+                &[0.0, 1.0, 0.0, 0.0],
+                "new memory",
+                "note",
+                "project",
+            )
+            .await
+            .expect("memory upsert");
+
+        let memories = store
+            .search_memories(&[0.0, 1.0, 0.0, 0.0], 10)
+            .await
+            .expect("search memories");
+        assert_eq!(memories.len(), 1);
+        assert_eq!(memories[0].content, "new memory");
+    }
+
+    #[tokio::test]
+    async fn delete_code_embeddings_is_scoped_to_project() {
+        let directory = tempfile::tempdir().expect("temporary LanceDB directory");
+        let store = LanceStore::open_with_dim(directory.path(), 4)
+            .await
+            .expect("open LanceDB");
+
+        store
+            .insert_code_embedding(
+                "keep",
+                &[1.0, 0.0, 0.0, 0.0],
+                "keep",
+                "function",
+                "project-a",
+                Some("src/a.rs"),
+                Some("rust"),
+            )
+            .await
+            .expect("insert project A");
+        store
+            .insert_code_embedding(
+                "replace",
+                &[0.0, 1.0, 0.0, 0.0],
+                "replace",
+                "function",
+                "project-b",
+                Some("src/b.rs"),
+                Some("rust"),
+            )
+            .await
+            .expect("insert project B");
+
+        store
+            .delete_code_embeddings_for_project("project-b")
+            .await
+            .expect("delete project B");
+
+        let results = store
+            .search_code(&[1.0, 0.0, 0.0, 0.0], 10)
+            .await
+            .expect("search after delete");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "keep");
+        assert_eq!(results[0].project_id, "project-a");
     }
 }

--- a/engine/src/watcher.rs
+++ b/engine/src/watcher.rs
@@ -2,9 +2,11 @@
 //!
 //! Monitors `~/.claude/projects/`, `~/.codex/sessions/`, and `~/.gemini/tmp/`
 //! for changes using the `notify` crate with debouncing, and invokes a callback
-//! when relevant files (`.json`, `.jsonl`) are modified.
+//! when relevant files (`.json`, `.jsonl`, `MEMORY.md`) are modified.
 
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::time::Duration;
 
@@ -19,6 +21,7 @@ use crate::config::AppConfig;
 pub struct FileWatcher {
     watch_paths: Vec<PathBuf>,
     debounce_ms: u64,
+    active: Arc<AtomicBool>,
 }
 
 impl FileWatcher {
@@ -27,7 +30,18 @@ impl FileWatcher {
         Self {
             watch_paths,
             debounce_ms,
+            active: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Return the configured watch paths.
+    pub fn watch_paths(&self) -> &[PathBuf] {
+        &self.watch_paths
+    }
+
+    /// Return whether a `run` call currently has at least one active watch.
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
     }
 
     /// Build watch paths from an [`AppConfig`], returning paths for enabled agents.
@@ -53,10 +67,16 @@ impl FileWatcher {
             let base = expand_tilde(&config.agents.gemini.path);
             paths.push(PathBuf::from(base).join("tmp"));
         }
+        for agent in &config.agents.dynamic {
+            if agent.enabled && agent.adapter_type == "jsonl" {
+                paths.push(PathBuf::from(expand_tilde(&agent.path)));
+            }
+        }
 
         Self {
             watch_paths: paths,
             debounce_ms: config.watch.debounce_ms,
+            active: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -91,6 +111,7 @@ impl FileWatcher {
 
         if active_watches == 0 {
             warn!("no valid directories to watch");
+            self.active.store(false, Ordering::SeqCst);
             return Ok(());
         }
 
@@ -98,12 +119,13 @@ impl FileWatcher {
             "file watcher started ({} directories, debounce={}ms)",
             active_watches, self.debounce_ms
         );
+        self.active.store(true, Ordering::SeqCst);
 
         // Block and process events.
         loop {
             match rx.recv() {
                 Ok(Ok(events)) => {
-                    // Filter to only .json and .jsonl files.
+                    // Filter to structured artifacts and agent memory notes.
                     let relevant: Vec<DebouncedEvent> = events
                         .into_iter()
                         .filter(|e| is_relevant_file(&e.path))
@@ -124,16 +146,25 @@ impl FileWatcher {
             }
         }
 
+        self.active.store(false, Ordering::SeqCst);
         Ok(())
     }
 }
 
-/// Returns `true` if the file path ends with `.json` or `.jsonl`.
+/// Returns `true` for structured artifacts or an agent memory file.
 fn is_relevant_file(path: &std::path::Path) -> bool {
-    matches!(
+    if matches!(
         path.extension().and_then(|e| e.to_str()),
         Some("json" | "jsonl")
-    )
+    ) {
+        return true;
+    }
+
+    // Agent memory files are Markdown, but recursively treating every README
+    // or documentation edit as an ingestion trigger would be noisy.
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("MEMORY.md"))
 }
 
 /// Expand a leading `~` in a path string to the user's home directory.
@@ -158,6 +189,7 @@ fn expand_tilde(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn test_new_creates_watcher() {
@@ -184,6 +216,27 @@ mod tests {
     }
 
     #[test]
+    fn test_from_config_includes_dynamic_jsonl_agents() {
+        let mut config = AppConfig::default();
+        config.agents.dynamic = vec![crate::ingest::DynamicAgentConfig {
+            id: "custom".into(),
+            display_name: "Custom".into(),
+            enabled: true,
+            path: "/tmp/custom-agent".into(),
+            adapter_type: "jsonl".into(),
+            sqlite: None,
+            jsonl: None,
+        }];
+
+        let watcher = FileWatcher::from_config(&config);
+        assert!(
+            watcher
+                .watch_paths()
+                .contains(&PathBuf::from("/tmp/custom-agent"))
+        );
+    }
+
+    #[test]
     fn test_expand_tilde() {
         let expanded = expand_tilde("~/.claude");
         assert!(!expanded.starts_with('~'), "tilde should be expanded");
@@ -198,7 +251,8 @@ mod tests {
     fn test_is_relevant_file() {
         assert!(is_relevant_file(std::path::Path::new("session.json")));
         assert!(is_relevant_file(std::path::Path::new("transcript.jsonl")));
-        assert!(!is_relevant_file(std::path::Path::new("readme.md")));
+        assert!(is_relevant_file(std::path::Path::new("MEMORY.md")));
+        assert!(!is_relevant_file(std::path::Path::new("README.md")));
         assert!(!is_relevant_file(std::path::Path::new("data.txt")));
         assert!(!is_relevant_file(std::path::Path::new("noextension")));
     }
@@ -209,5 +263,39 @@ mod tests {
         // Should return Ok(()) without blocking when no dirs exist.
         let result = watcher.run(|_events| {});
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_run_detects_jsonl_changes() {
+        let directory = TempDir::new().unwrap();
+        let artifact = directory.path().join("session.jsonl");
+        std::fs::write(&artifact, "{}\n").unwrap();
+        let sender_path = std::sync::Arc::new(artifact.clone());
+        let (event_tx, event_rx) = std::sync::mpsc::channel();
+
+        let watcher = FileWatcher::new(vec![directory.path().to_path_buf()], 100);
+        let watcher_active = Arc::clone(&watcher.active);
+        std::thread::spawn(move || {
+            let path = sender_path;
+            let _ = watcher.run(move |_events| {
+                let _ = event_tx.send(path.clone());
+            });
+        });
+
+        for _ in 0..100 {
+            if watcher_active.load(std::sync::atomic::Ordering::SeqCst) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            watcher_active.load(std::sync::atomic::Ordering::SeqCst),
+            "watcher did not become active"
+        );
+        std::fs::write(&artifact, "{\"update\":true}\n").unwrap();
+        let changed = event_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("watcher should report the changed artifact");
+        assert_eq!(changed.as_path(), artifact.as_path());
     }
 }

--- a/engine/tests/integration_test.rs
+++ b/engine/tests/integration_test.rs
@@ -7,7 +7,6 @@ use chrono::{NaiveDateTime, Utc};
 use remembrant_engine::embedding::MockEmbedder;
 use remembrant_engine::graph_builder::GraphBuilder;
 use remembrant_engine::store::duckdb::{Decision, DuckStore, Memory, Session, ToolCall};
-use remembrant_engine::store::graph::NodeKind;
 use remembrant_engine::store::lance::LanceStore;
 use remembrant_engine::{EmbedChunk, EmbedPipeline, Granularity};
 use tempfile::tempdir;
@@ -181,7 +180,7 @@ fn test_graph_builder_from_sessions() -> Result<()> {
         node_count >= 3,
         "Expected at least 3 nodes (2 sessions + 1 memory)"
     );
-    assert!(edge_count >= 0, "Expected at least 0 edges");
+    assert!(edge_count > 0, "Expected graph builder to create edges");
 
     // Graph building completed successfully
 
@@ -240,7 +239,8 @@ async fn test_embed_pipeline_with_mock() -> Result<()> {
     // Create embed chunks manually
     let chunks = vec![
         EmbedChunk {
-            id: Uuid::new_v4().to_string(),
+            id: "integration-session-embedding".to_string(),
+            source_id: Some(session1.id.clone()),
             content: session1.summary.clone().unwrap(),
             granularity: Granularity::Session,
             project_id: session1.project_id.clone(),
@@ -249,7 +249,8 @@ async fn test_embed_pipeline_with_mock() -> Result<()> {
             language: None,
         },
         EmbedChunk {
-            id: Uuid::new_v4().to_string(),
+            id: "integration-memory-embedding".to_string(),
+            source_id: Some(memory1.id.clone()),
             content: memory1.content.clone(),
             granularity: Granularity::Memory,
             project_id: memory1.project_id.clone(),


### PR DESCRIPTION
## Summary

Full correctness-and-completeness pass over Remembrant: deep audit of every documented command, API, and config field; fixes for all issues found; a comprehensive CLI/MCP E2E suite; and modernization to August 2026 baselines.

## Highlights

**MCP — Model Context Protocol 2026-07-28**
- Stateless, cacheable stdio discovery with version negotiation and metadata validation
- Legacy `initialize` compatibility preserved
- Deterministic, sorted tool listings with `resultType`/`cacheScope`/`ttlMs` metadata

**Ingestion**
- Generic YAML-mapped JSONL adapter (`jsonl_adapter.rs`) for arbitrary agent formats
- Config-aware native + dynamic adapter registry
- Debounced, event-driven watcher for JSON/JSONL artifacts and agent `MEMORY.md` files

**Web dashboard & API**
- Dashboard split into embedded HTML/CSS/JS assets (same-origin, no permissive CORS)
- CRUD API hardening, memory-tag parity, bounded pagination limits, UTC timestamps

**Semantic XPath**
- Root node id canonicalized to `Root` (case-insensitive lookup) so tree paths render `Root -> …` consistently across CLI `--tree`, hybrid-search `xpath_path`, `/api/search/xpath`, and the dashboard

**Correctness fixes from the audit**
- Unicode-safe truncation, idempotent session/embedding writes, cascade cleanup, timeout handling, config validation, RFC 3339 `--since` parsing with range checks

**Tests**
- New ~1.2k-line CLI E2E suite: ingest → search/xpath → dashboard APIs → full MCP protocol (legacy + modern) → tool calls → forget semantics
- 268 engine unit tests, 11 CLI unit tests, 6 integration tests; feature-gated code-analysis tests (276 engine)

**Docs & CI**
- AGENTS.md + README refreshed for all 26 commands and the current architecture
- CI runs fmt, default + code-analysis tests, both clippy configs (`-D warnings`), and dashboard JS syntax check, with pinned action versions

## Verification (all green locally)

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets`
- `cargo test --workspace --all-targets --features code-analysis`
- `cargo clippy --workspace --all-targets -- -D warnings` (both feature configs)
- `node --check cli/src/web_dashboard.js`

🤖 Continued from an audited agent session; final gates re-run and any remaining failures fixed before commit.